### PR TITLE
Prevent transformation of numbers in string

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -203,7 +203,7 @@ async function run(oaFile, options) {
     output = JSON.stringify(res, null, 2);
 
     // Decode stringified large number JSON values safely before writing output
-    const regexDecodeJsonLargeNumber = /: ([0-9]*\.?[0-9]+)/g; // match > : 123456789.123456789===
+    const regexDecodeJsonLargeNumber = /: "([0-9]*\.?[0-9]+)==="/g; // match > : "123456789.123456789"===
     output = output.replace(regexDecodeJsonLargeNumber, (strNumber) => {
       const number = strNumber.replace(/: "|"/g, '');
       // Decode large numbers safely in javascript

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -149,7 +149,7 @@ async function run(oaFile, options) {
   infoOut(`- Input file:\t\t${oaFile}`) // LOG - Input file
 
   // Read input file
-  let inputContent = fs.readFileSync( oaFile, 'utf8' );
+  let inputContent = fs.readFileSync(oaFile, 'utf8');
 
   // Convert large number value safely before parsing
   const regexEncodeLargeNumber = /: ([0-9]*\.?[0-9]+)(,|\n)/g;  // match > : 123456789.123456789
@@ -159,7 +159,7 @@ async function run(oaFile, options) {
     const number = rawInput.replace(/: /g, '').replace(rgx, '');
     // Handle large numbers safely in javascript
     if (!Number.isSafeInteger(Number(number)) || number.replace('.', '').length > 15) {
-      return `: '${number}'${endChar}`;
+      return `: '${number}==='${endChar}`;
     } else {
       return `: ${number}${endChar}`;
     }
@@ -203,12 +203,12 @@ async function run(oaFile, options) {
     output = JSON.stringify(res, null, 2);
 
     // Decode stringified large number JSON values safely before writing output
-    const regexDecodeJsonLargeNumber = /: "([0-9]*\.?[0-9]+)"/g; // match > : "123456789.123456789"
+    const regexDecodeJsonLargeNumber = /: ([0-9]*\.?[0-9]+)/g; // match > : 123456789.123456789===
     output = output.replace(regexDecodeJsonLargeNumber, (strNumber) => {
       const number = strNumber.replace(/: "|"/g, '');
       // Decode large numbers safely in javascript
-      if (!Number.isSafeInteger(Number(number)) || number.replace('.', '').length > 15) {
-        return strNumber.replace(/"/g, '')
+      if (number.endsWith('===') || number.replace('.', '').length > 15) {
+        return strNumber.replace('===', '').replace(/"/g, '')
       } else {
         // Keep stringified number
         return strNumber;
@@ -220,12 +220,12 @@ async function run(oaFile, options) {
     output = sy.safeStringify(res, {lineWidth: lineWidth});
 
     // Decode stringified large number YAML values safely before writing output
-    const regexDecodeYamlLargeNumber = /: '([0-9]*\.?[0-9]+)'/g; // match > : '123456789.123456789'
+    const regexDecodeYamlLargeNumber = /: ([0-9]*\.?[0-9]+)===/g; // match > : 123456789.123456789===
     output = output.replace(regexDecodeYamlLargeNumber, (strNumber) => {
       const number = strNumber.replace(/: '|'/g, '');
       // Decode large numbers safely in javascript
-      if (!Number.isSafeInteger(Number(number)) || number.replace('.', '').length > 15) {
-        return strNumber.replace(/'/g, '')
+      if (number.endsWith('===') || number.replace('.', '').length > 15) {
+        return strNumber.replace('===', '').replace(/'/g, '')
       } else {
         // Keep stringified number
         return strNumber;

--- a/test/json-default-bug-big-numbers/input.json
+++ b/test/json-default-bug-big-numbers/input.json
@@ -26,6 +26,7 @@
   "components": {
     "schemas": {
       "Pet": {
+        "title": "500.1",
         "type": "object",
         "properties": {
           "properties": {
@@ -36,6 +37,10 @@
             "type": "integer",
             "format": "int64",
             "example": 10
+          },
+          "title": {
+            "type": "string",
+            "example": "500.1"
           },
           "name": {
             "type": "string",

--- a/test/json-default-bug-big-numbers/output.json
+++ b/test/json-default-bug-big-numbers/output.json
@@ -26,6 +26,7 @@
   "components": {
     "schemas": {
       "Pet": {
+        "title": "500.1",
         "type": "object",
         "properties": {
           "properties": {
@@ -36,6 +37,10 @@
             "type": "integer",
             "format": "int64",
             "example": 10
+          },
+          "title": {
+            "type": "string",
+            "example": "500.1"
           },
           "name": {
             "type": "string",

--- a/test/test.js
+++ b/test/test.js
@@ -195,7 +195,7 @@ describe('openapi-format tests', () => {
             const number = rawInput.replace(/: /g, '');
             // Handle large numbers safely in javascript
             if (!Number.isSafeInteger(Number(number)) || number.replace('.', '').length > 15) {
-              return `: "${number}"`;
+              return `: "${number}==="`;
             } else {
               return `: ${number}`;
             }
@@ -240,7 +240,7 @@ describe('openapi-format tests', () => {
               output = JSON.stringify(result, null, 2);
 
               // Decode stringified large number JSON values safely before writing output
-              const regexDecodeJsonLargeNumber = /: ([0-9]*\.?[0-9]+)===/g; // match > : 123456789.123456789===
+              const regexDecodeJsonLargeNumber = /: "([0-9]*\.?[0-9]+)==="/g; // match > : "123456789.123456789"===
               output = output.replace(regexDecodeJsonLargeNumber, (strNumber) => {
                 const number = strNumber.replace(/: "|"/g, '');
                 // Decode large numbers safely in javascript

--- a/test/test.js
+++ b/test/test.js
@@ -158,7 +158,7 @@ describe('openapi-format tests', () => {
           const number = rawInput.replace(/: /g, '').replace(rgx, '');
           // Handle large numbers safely in javascript
           if (!Number.isSafeInteger(Number(number)) || number.replace('.', '').length > 15) {
-            return `: '${number}'${endChar}`;
+            return `: '${number}==='${endChar}`;
           } else {
             return `: ${number}${endChar}`;
           }
@@ -240,12 +240,12 @@ describe('openapi-format tests', () => {
               output = JSON.stringify(result, null, 2);
 
               // Decode stringified large number JSON values safely before writing output
-              const regexDecodeJsonLargeNumber = /: "([0-9]*\.?[0-9]+)"/g; // match > : "123456789.123456789"
+              const regexDecodeJsonLargeNumber = /: ([0-9]*\.?[0-9]+)===/g; // match > : 123456789.123456789===
               output = output.replace(regexDecodeJsonLargeNumber, (strNumber) => {
                 const number = strNumber.replace(/: "|"/g, '');
                 // Decode large numbers safely in javascript
-                if (!Number.isSafeInteger(Number(number)) || number.replace('.', '').length > 15) {
-                  return strNumber.replace(/"/g, '')
+                if (number.endsWith('===') || number.replace('.', '').length > 15) {
+                  return strNumber.replace('===', '').replace(/"/g, '')
                 } else {
                   // Keep stringified number
                   return strNumber;
@@ -257,12 +257,12 @@ describe('openapi-format tests', () => {
               output = sy.safeStringify(result, {lineWidth: lineWidth});
 
               // Decode stringified large number YAML values safely before writing output
-              const regexDecodeYamlLargeNumber = /: '([0-9]*\.?[0-9]+)'/g; // match > : '123456789.123456789'
+              const regexDecodeYamlLargeNumber = /: ([0-9]*\.?[0-9]+)===/g; // match > : 123456789.123456789===
               output = output.replace(regexDecodeYamlLargeNumber, (strNumber) => {
                 const number = strNumber.replace(/: '|'/g, '');
                 // Decode large numbers safely in javascript
-                if (!Number.isSafeInteger(Number(number)) || number.replace('.', '').length > 15) {
-                  return strNumber.replace(/'/g, '')
+                if (number.endsWith('===') || number.replace('.', '').length > 15) {
+                  return strNumber.replace('===', '').replace(/'/g, '')
                 } else {
                   // Keep stringified number
                   return strNumber;

--- a/test/yaml-default-bug-big-numbers/input.yaml
+++ b/test/yaml-default-bug-big-numbers/input.yaml
@@ -16,6 +16,7 @@ paths:
 components:
   schemas:
     Pet:
+      title: '500.1'
       type: object
       properties:
         properties:
@@ -25,6 +26,9 @@ components:
           type: integer
           format: int64
           example: 10
+        title:
+          type: string
+          example: 500.1
         name:
           type: string
           example: 123456789012345678901234567890

--- a/test/yaml-default-bug-big-numbers/output.yaml
+++ b/test/yaml-default-bug-big-numbers/output.yaml
@@ -16,6 +16,7 @@ paths:
 components:
   schemas:
     Pet:
+      title: '500.1'
       type: object
       properties:
         properties:
@@ -25,6 +26,9 @@ components:
           type: integer
           format: int64
           example: 10
+        title:
+          type: string
+          example: 500.1
         name:
           type: string
           example: 123456789012345678901234567890


### PR DESCRIPTION
Fix for unwanted number conversions by adding a "marking" to the number values.