### PR TITLE
Bug fix for components.examples.properties

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -152,7 +152,7 @@ async function run(oaFile, options) {
   let inputContent = fs.readFileSync(oaFile, 'utf8');
 
   // Convert large number value safely before parsing
-  const regexEncodeLargeNumber = /: ([0-9]*\.?[0-9]+)(,|\n)/g;  // match > : 123456789.123456789
+  const regexEncodeLargeNumber = /: ([0-9]+(\.[0-9]+)?)\b(?!\.[0-9])(,|\n)/g;  // match > : 123456789.123456789
   inputContent = inputContent.replace(regexEncodeLargeNumber, (rawInput) => {
     const endChar = (rawInput.endsWith(',') ? ',' : '\n');
     const rgx = new RegExp(endChar, "g");
@@ -203,7 +203,7 @@ async function run(oaFile, options) {
     output = JSON.stringify(res, null, 2);
 
     // Decode stringified large number JSON values safely before writing output
-    const regexDecodeJsonLargeNumber = /: "([0-9]*\.?[0-9]+)==="/g; // match > : "123456789.123456789"===
+    const regexDecodeJsonLargeNumber = /: "([0-9]+(\.[0-9]+)?)\b(?!\.[0-9])==="/g; // match > : "123456789.123456789"===
     output = output.replace(regexDecodeJsonLargeNumber, (strNumber) => {
       const number = strNumber.replace(/: "|"/g, '');
       // Decode large numbers safely in javascript
@@ -220,7 +220,7 @@ async function run(oaFile, options) {
     output = sy.safeStringify(res, {lineWidth: lineWidth});
 
     // Decode stringified large number YAML values safely before writing output
-    const regexDecodeYamlLargeNumber = /: ([0-9]*\.?[0-9]+)===/g; // match > : 123456789.123456789===
+    const regexDecodeYamlLargeNumber = /: ([0-9]+(\.[0-9]+)?)\b(?!\.[0-9])===/g; // match > : 123456789.123456789===
     output = output.replace(regexDecodeYamlLargeNumber, (strNumber) => {
       const number = strNumber.replace(/: '|'/g, '');
       // Decode large numbers safely in javascript

--- a/openapi-format.js
+++ b/openapi-format.js
@@ -196,7 +196,7 @@ async function openapiSort(oaObj, options) {
           this.update(sortedObj);
 
         } else if ((this.key === 'responses' || this.key === 'schemas' || this.key === 'properties')
-          && (this.parent && this.parent.key !== 'properties' && this.parent.key !== 'value')
+          && (this.parent && this.parent.key !== 'properties' && this.parent.key !== 'value' && this.path[1] !== 'examples')
         ) {
           // debugStep = 'Generic sorting - responses/schemas/properties'
           // Deep sort list of properties
@@ -330,7 +330,7 @@ async function openapiFilter(oaObj, options) {
     }
 
     // Filter out object matching the "response content"
-    if (filterResponseContent.length > 0 && filterResponseContent.includes(this.key) 
+    if (filterResponseContent.length > 0 && filterResponseContent.includes(this.key)
       && this.parent && this.parent.key === 'content'
       && this.parent.parent && this.parent.parent.parent && this.parent.parent.parent.key === 'responses') {
       // debugFilterStep = 'Filter - response content'
@@ -338,7 +338,7 @@ async function openapiFilter(oaObj, options) {
     }
 
     // Filter out object matching the inverse "response content"
-    if (inverseFilterResponseContent.length > 0 && !inverseFilterResponseContent.includes(this.key) 
+    if (inverseFilterResponseContent.length > 0 && !inverseFilterResponseContent.includes(this.key)
       && this.parent && this.parent.key === 'content'
       && this.parent.parent && this.parent.parent.parent && this.parent.parent.parent.key === 'responses') {
       // debugFilterStep = 'Filter - inverse response content'

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,7 @@ const tests = fs.readdirSync(__dirname).filter(file => {
 });
 
 // SELECTIVE TESTING DEBUG
-// const tests = ['yaml-default-bug-big-numbers']
+// const tests = ['yaml-default-bug-examples-value']
 // destroyOutput = true
 
 describe('openapi-format tests', () => {
@@ -151,7 +151,7 @@ describe('openapi-format tests', () => {
         }
 
         // Convert large number value safely before parsing
-        const regexEncodeLargeNumber = /: ([0-9]*\.?[0-9]+)(,|\n)/g;  // match > : 123456789.123456789
+        const regexEncodeLargeNumber = /: ([0-9]+(\.[0-9]+)?)\b(?!\.[0-9])(,|\n)/g;  // match > : 123456789.123456789
         inputContent = inputContent.replace(regexEncodeLargeNumber, (rawInput) => {
           const endChar = (rawInput.endsWith(',') ? ',' : '\n');
           const rgx = new RegExp(endChar, "g");
@@ -190,7 +190,7 @@ describe('openapi-format tests', () => {
           let outputContent = fs.readFileSync(outputFilename, 'utf8');
 
           // Convert large number value safely before parsing
-          const regexEncodeLargeNumber = /: ([0-9]*\.?[0-9]+)/g;  // match > : 123456789.123456789
+          const regexEncodeLargeNumber = /: ([0-9]+(\.[0-9]+)?)\b(?!\.[0-9])/g;  // match > : 123456789.123456789
           outputContent = outputContent.replace(regexEncodeLargeNumber, (rawInput) => {
             const number = rawInput.replace(/: /g, '');
             // Handle large numbers safely in javascript
@@ -240,7 +240,7 @@ describe('openapi-format tests', () => {
               output = JSON.stringify(result, null, 2);
 
               // Decode stringified large number JSON values safely before writing output
-              const regexDecodeJsonLargeNumber = /: "([0-9]*\.?[0-9]+)==="/g; // match > : "123456789.123456789"===
+              const regexDecodeJsonLargeNumber = /: "([0-9]+(\.[0-9]+)?)\b(?!\.[0-9])==="/g; // match > : "123456789.123456789"===
               output = output.replace(regexDecodeJsonLargeNumber, (strNumber) => {
                 const number = strNumber.replace(/: "|"/g, '');
                 // Decode large numbers safely in javascript
@@ -257,7 +257,7 @@ describe('openapi-format tests', () => {
               output = sy.safeStringify(result, {lineWidth: lineWidth});
 
               // Decode stringified large number YAML values safely before writing output
-              const regexDecodeYamlLargeNumber = /: ([0-9]*\.?[0-9]+)===/g; // match > : 123456789.123456789===
+              const regexDecodeYamlLargeNumber = /: ([0-9]+(\.[0-9]+)?)\b(?!\.[0-9])===/g; // match > : 123456789.123456789===
               output = output.replace(regexDecodeYamlLargeNumber, (strNumber) => {
                 const number = strNumber.replace(/: '|'/g, '');
                 // Decode large numbers safely in javascript

--- a/test/yaml-default-bug-examples-properties/input.yaml
+++ b/test/yaml-default-bug-examples-properties/input.yaml
@@ -804,6 +804,24 @@ components:
             - tag1
             - tag 2
       summary: A payload example for a notification
+    sample-mobile-sdk-custom-event-batch:
+      value:
+        - id: 0149531b-fac2-476f-ab71-f29bc9030582d
+          source: sdc/mobile/sdk/device/6fa2d7d5-b374-4c42-8e1f-e05bac6136b4
+          type: sdc.mobile.sdk.events.custom
+          time: '2022-03-15T14:17:32.7430000Z'
+          specversion: '1.0'
+          dataschema: '#/sdc/events/mobilesdk/customevent/v1'
+          datacontenttype: application/json
+          subject: /reference/788c7647-1bc1-43db-b25d-13d8544bc1de
+          sdkversion: "2.7.1"
+          sdktype: "ios_library_plotprojects"
+          sdkdevice: "be958275ae9e4d50ada7eb724c7d34a2"
+          sdkos: "ios"
+          data:
+            name: EVENT_DEFINITION_1
+            properties:
+              last_chapter: 'chapter1'
   requestBodies:
     Pet:
       content:

--- a/test/yaml-default-bug-examples-properties/input.yaml
+++ b/test/yaml-default-bug-examples-properties/input.yaml
@@ -807,15 +807,15 @@ components:
     sample-mobile-sdk-custom-event-batch:
       value:
         - id: 0149531b-fac2-476f-ab71-f29bc9030582d
-          source: sdc/mobile/sdk/device/6fa2d7d5-b374-4c42-8e1f-e05bac6136b4
-          type: sdc.mobile.sdk.events.custom
+          source: mobile/sdk/device/6fa2d7d5-b374-4c42-8e1f-e05bac6136b4
+          type: mobile.sdk.events.custom
           time: '2022-03-15T14:17:32.7430000Z'
           specversion: '1.0'
-          dataschema: '#/sdc/events/mobilesdk/customevent/v1'
+          dataschema: '#/events/mobilesdk/customevent/v1'
           datacontenttype: application/json
           subject: /reference/788c7647-1bc1-43db-b25d-13d8544bc1de
           sdkversion: "2.7.1"
-          sdktype: "ios_library_plotprojects"
+          sdktype: "ios_library"
           sdkdevice: "be958275ae9e4d50ada7eb724c7d34a2"
           sdkos: "ios"
           data:

--- a/test/yaml-default-bug-examples-properties/output.yaml
+++ b/test/yaml-default-bug-examples-properties/output.yaml
@@ -804,6 +804,24 @@ components:
             - tag1
             - tag 2
       summary: A payload example for a notification
+    sample-mobile-sdk-custom-event-batch:
+      value:
+        - id: 0149531b-fac2-476f-ab71-f29bc9030582d
+          source: sdc/mobile/sdk/device/6fa2d7d5-b374-4c42-8e1f-e05bac6136b4
+          type: sdc.mobile.sdk.events.custom
+          time: '2022-03-15T14:17:32.7430000Z'
+          specversion: '1.0'
+          dataschema: '#/sdc/events/mobilesdk/customevent/v1'
+          datacontenttype: application/json
+          subject: /reference/788c7647-1bc1-43db-b25d-13d8544bc1de
+          sdkversion: 2.7.1
+          sdktype: ios_library_plotprojects
+          sdkdevice: be958275ae9e4d50ada7eb724c7d34a2
+          sdkos: ios
+          data:
+            name: EVENT_DEFINITION_1
+            properties:
+              last_chapter: chapter1
   requestBodies:
     Pet:
       content:

--- a/test/yaml-default-bug-examples-properties/output.yaml
+++ b/test/yaml-default-bug-examples-properties/output.yaml
@@ -807,15 +807,15 @@ components:
     sample-mobile-sdk-custom-event-batch:
       value:
         - id: 0149531b-fac2-476f-ab71-f29bc9030582d
-          source: sdc/mobile/sdk/device/6fa2d7d5-b374-4c42-8e1f-e05bac6136b4
-          type: sdc.mobile.sdk.events.custom
+          source: mobile/sdk/device/6fa2d7d5-b374-4c42-8e1f-e05bac6136b4
+          type: mobile.sdk.events.custom
           time: '2022-03-15T14:17:32.7430000Z'
           specversion: '1.0'
-          dataschema: '#/sdc/events/mobilesdk/customevent/v1'
+          dataschema: '#/events/mobilesdk/customevent/v1'
           datacontenttype: application/json
           subject: /reference/788c7647-1bc1-43db-b25d-13d8544bc1de
           sdkversion: 2.7.1
-          sdktype: ios_library_plotprojects
+          sdktype: ios_library
           sdkdevice: be958275ae9e4d50ada7eb724c7d34a2
           sdkos: ios
           data:


### PR DESCRIPTION
This PR fixes the issue, when the components.examples has a property `properties`, the output gets distorted:

INPUT:
```yaml
components:
  examples:
    sample-mobile-sdk-custom-event-batch:
      value:
        - id: 0149531b-fac2-476f-ab71-f29bc9030582d
          data:
            name: EVENT_DEFINITION_1
            properties:
              last_chapter: chapter1
```

OUTPUT:
```yaml
components:
  examples:
    sample-mobile-sdk-custom-event-batch:
      value:
        - id: 0149531b-fac2-476f-ab71-f29bc9030582d
          data:
            name: EVENT_DEFINITION_1
            properties:
              last_chapter: 
                 0: c
                 1: h
                 2: a
                 3: p
                 4: t
                 5: e
                 6: r
                 7: 1
```
