### PR TITLE
Don't throw if `name` doesn't exist

### DIFF
--- a/util-sort.js
+++ b/util-sort.js
@@ -64,8 +64,8 @@ function prioritySort(jsonProp, sortPriority, options) {
  */
 function arraySort(arr, propertyName) {
   return arr.sort((a, b) => {
-    const propA = a[propertyName].toLowerCase();
-    const propB = b[propertyName].toLowerCase();
+    const propA = a[propertyName] ? a[propertyName].toLowerCase() : '';
+    const propB = b[propertyName] ? b[propertyName].toLowerCase() : '';
 
     if (propA < propB) {
       return -1;


### PR DESCRIPTION
After updating to 1.15.0, we saw some failures due to `name` property not existing and sorting failing.