### PR TITLE
Filter - Added inverse filtering for flags and flagValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
 
+- Filter - Added inverse filtering for flags for operations, components, tags, x-tagGroups
 - Filter - Added inverse filtering for flagValues for operations, components, tags, x-tagGroups
 - Support http & https remote files
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## unreleased
 
-- Filter - Added inverse filtering for flagValues via `inverseFlagValues`
+- Filter - Added inverse filtering for flagValues for operations, components, tags, x-tagGroups
 - Support http & https remote files
 
 ## [1.16.0] - 2024-01-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## unreleased
 
+- Filter - Added inverse filtering for flagValues via `inverseFlagValues`
 - Support http & https remote files
 
 ## [1.16.0] - 2024-01-16

--- a/defaultFilter.json
+++ b/defaultFilter.json
@@ -8,6 +8,7 @@
   "operations": [],
   "flags": [],
   "flagValues": [],
+  "inverseFlagValues": [],
   "unusedComponents": [],
   "stripFlags": [],
   "responseContent": [],

--- a/defaultFilter.json
+++ b/defaultFilter.json
@@ -7,6 +7,7 @@
   "inverseOperationIds": [],
   "operations": [],
   "flags": [],
+  "inverseFlags": [],
   "flagValues": [],
   "inverseFlagValues": [],
   "unusedComponents": [],

--- a/openapi-format.js
+++ b/openapi-format.js
@@ -147,6 +147,7 @@ async function openapiFilter(oaObj, options) {
   const inverseFilterKeys = [...filterSet.inverseMethods];
   const inverseFilterProps = [...filterSet.inverseOperationIds];
   const inverseFilterArray = [...filterSet.inverseTags];
+  const inverseFilterFlags = [...filterSet.inverseFlags];
   const inverseFilterResponseContent = [...filterSet.inverseResponseContent];
 
   const stripFlags = [...filterSet.stripFlags];
@@ -312,26 +313,35 @@ async function openapiFilter(oaObj, options) {
         }
       }
 
-      // Filter out fields matching the inverseFlagValues array
-      if (inverseFilterFlagValuesKeys.length > 0 && (this.path[0] === 'tags' || this.path[0] === 'x-tagGroups')) {
+      // Keep fields matching the inverseFlags array
+      if (inverseFilterFlags.length > 0 && (this.path[0] === 'tags' || this.path[0] === 'x-tagGroups') && this.level === 1) {
         let oaTags = JSON.parse(JSON.stringify(node));
 
-        for (let i = 0; i < oaTags.length; i++) {
-          const itmObj = oaTags[i];
-          // Iterate over inverseFilterFlagValuesKeys and check if any key exists in itmObj with a matching value
-          const matchesInverseFlag = inverseFilterFlagValues.some(flagObj => {
+        oaTags = oaTags.filter(itmObj => {
+          return inverseFilterFlags.some(flagKey => {
+            return itmObj.hasOwnProperty(flagKey);
+          });
+        });
+
+        // Update the node with the filtered array
+        node = oaTags;
+        this.update(node);
+      }
+
+      // Keep the fields matching the inverseFlagValues array
+      if (inverseFilterFlagValuesKeys.length > 0 && (this.path[0] === 'tags' || this.path[0] === 'x-tagGroups') && this.level === 1) {
+        let oaTags = JSON.parse(JSON.stringify(node));
+
+        oaTags = oaTags.filter(itmObj => {
+          // keep the item in the array if any of the inverseFilterFlags is a property of itmObj with a matching value
+          return inverseFilterFlagValues.some(flagObj => {
             const flagKey = Object.keys(flagObj)[0];  // Get the key of the flagObj
             const flagValue = flagObj[flagKey];  // Get the value of the flagObj
 
             // Check if the key exists in itmObj and if its value matches the value in flagObj
             return itmObj.hasOwnProperty(flagKey) && itmObj[flagKey] === flagValue;
           });
-
-          if (!matchesInverseFlag) {
-            // remove from oaTags array
-            oaTags.splice(i, 1);
-          }
-        }
+        });
 
         // Update the node with the filtered array
         node = oaTags;
@@ -404,7 +414,21 @@ async function openapiFilter(oaObj, options) {
       }
     }
 
-    // Keep fields matching the inverseFlagValues single value
+    // Keep fields matching the inverseFlags
+    if (inverseFilterFlags.length > 0
+      && ((this.path[0] === 'paths' && this.level === 3) || (this.path[0] === 'components' && this.level === 3))) {
+      const itmObj = node;
+      const matchesInverseFlag = inverseFilterFlags.some(flagKey => {
+        return itmObj.hasOwnProperty(flagKey);
+      });
+
+      if (!matchesInverseFlag) {
+        // debugFilterStep = 'Filter - Single field - inverseFlags'
+        this.remove();
+      }
+    }
+
+    // Keep fields matching the inverseFlagValues
     if (inverseFilterFlagValuesKeys.length > 0 && ((this.path[0] === 'paths' && this.level === 3) || (this.path[0] === 'components' && this.level === 3))) {
       const itmObj = node;
       const matchesInverseFlag = inverseFilterFlagValues.some(flagObj => {

--- a/readme.md
+++ b/readme.md
@@ -217,6 +217,7 @@ extended options for filtering OpenAPI documents.
 | inverseOperationIds    | OpenAPI operation ID's that will be kept    | array | ['findPetsByStatus','updatePet']          |
 | operations             | OpenAPI operations                          | array | ['GET::/pets','PUT::/pets']               |
 | flags                  | Custom flags                                | array | ['x-exclude','x-internal']                |
+| inverseFlags           | Custom flags that will kept                 | array | ['x-exclude','x-internal']                |
 | flagValues             | Custom flags with a specific value          | array | ['x-version: 1.0','x-version: 3.0']       |
 | inverseFlagValues      | Custom flags with a value that will be kept | array | ['x-version: 1.0','x-version: 3.0']       |
 | responseContent        | Response Content types                      | array | ['application/json','application/html']   |
@@ -345,7 +346,7 @@ This will target only the "GET" method and any path matching any folder behind t
 Method & Path wildcard matching example: `"*::/pets/*"`
 A combination of wildcards for the method and path parts is even possible.
 
-### Filter - flags
+### Filter - flags/inverseFlags
 
 => **flags**: Refers to a custom property that can be set on any field in the OpenAPI document.
 
@@ -364,6 +365,8 @@ paths:
         get:
             x-exclude: true
 ```
+
+=> **inverseFlags**: This option does the inverse filtering, by keeping only the operations, components, tags, x-tagGroups that match the flag(s). This is a very aggressive option to keep only the items that are needed.
 
 ### Filter - flagValues/inverseFlagValues
 

--- a/readme.md
+++ b/readme.md
@@ -207,22 +207,23 @@ matching item from the OpenAPI document. You can combine multiple types to filte
 For more complex use-cases, we can advise the excellent https://github.com/Mermade/openapi-filter package, which has
 extended options for filtering OpenAPI documents.
 
-| Type                   | Description                                | Type  | Examples                                  |
-|------------------------|--------------------------------------------|-------|-------------------------------------------|
-| methods                | OpenAPI methods.                           | array | ['get','post','put']                      |
-| inverseMethods         | OpenAPI methods that will be kept          | array | ['get','post','put']                      |
-| tags                   | OpenAPI tags                               | array | ['pet','user']                            |
-| inverseTags            | OpenAPI tags that will be kept             | array | ['pet','user']                            |
-| operationIds           | OpenAPI operation ID's                     | array | ['findPetsByStatus','updatePet']          |
-| inverseOperationIds    | OpenAPI operation ID's that will be kept   | array | ['findPetsByStatus','updatePet']          |
-| operations             | OpenAPI operations                         | array | ['GET::/pets','PUT::/pets']               |
-| flags                  | Custom flags                               | array | ['x-exclude','x-internal']                |
-| flagValues             | Custom flags with a specific value         | array | ['x-version: 1.0','x-version: 3.0']       |
-| responseContent        | Response Content types                     | array | ['application/json','application/html']   |
-| inverseResponseContent | Response Content types that will kept      | array | ['application/ld+json']                   |
-| unusedComponents       | Unused components                          | array | ['examples','schemas']                    |
-| stripFlags             | Custom flags that will be stripped         | array | ['x-exclude','x-internal']                |
-| textReplace            | Search & replace values to replace         | array | [{'searchFor':'Pet','replaceWith':'Dog'}] |
+| Type                   | Description                                 | Type  | Examples                                  |
+|------------------------|---------------------------------------------|-------|-------------------------------------------|
+| methods                | OpenAPI methods.                            | array | ['get','post','put']                      |
+| inverseMethods         | OpenAPI methods that will be kept           | array | ['get','post','put']                      |
+| tags                   | OpenAPI tags                                | array | ['pet','user']                            |
+| inverseTags            | OpenAPI tags that will be kept              | array | ['pet','user']                            |
+| operationIds           | OpenAPI operation ID's                      | array | ['findPetsByStatus','updatePet']          |
+| inverseOperationIds    | OpenAPI operation ID's that will be kept    | array | ['findPetsByStatus','updatePet']          |
+| operations             | OpenAPI operations                          | array | ['GET::/pets','PUT::/pets']               |
+| flags                  | Custom flags                                | array | ['x-exclude','x-internal']                |
+| flagValues             | Custom flags with a specific value          | array | ['x-version: 1.0','x-version: 3.0']       |
+| inverseFlagValues      | Custom flags with a value that will be kept | array | ['x-version: 1.0','x-version: 3.0']       |
+| responseContent        | Response Content types                      | array | ['application/json','application/html']   |
+| inverseResponseContent | Response Content types that will kept       | array | ['application/ld+json']                   |
+| unusedComponents       | Unused components                           | array | ['examples','schemas']                    |
+| stripFlags             | Custom flags that will be stripped          | array | ['x-exclude','x-internal']                |
+| textReplace            | Search & replace values to replace          | array | [{'searchFor':'Pet','replaceWith':'Dog'}] |
 
 Some more details on the available filter types:
 
@@ -364,7 +365,7 @@ paths:
             x-exclude: true
 ```
 
-### Filter - flagValues
+### Filter - flagValues/inverseFlagValues
 
 => **flagValues**: Refers to a flag, custom property which can be set on any field in the OpenAPI document, and the combination with the value for that flag.
 
@@ -417,6 +418,8 @@ paths:
 ```
 
 Have a look at [flagValues](test/yaml-filter-custom-flagsvalue-value) and [flagValues for array values](test/yaml-filter-custom-flagsvalue-array) for a practical example.
+
+=> **inverseFlagValues**: This option does the inverse filtering, by keeping only the operations, components, tags, x-tagGroups that match the flag with the specific value. This is a very aggressive option to keep only the items that are needed.
 
 ### Filter - responseContent/inverseResponseContent
 

--- a/test/util-file.test.js
+++ b/test/util-file.test.js
@@ -178,10 +178,11 @@ describe('openapi-format CLI file tests', () => {
   });
 
   describe('getRemoteFile function', () => {
-    const validRemoteFilePath = 'https://raw.githubusercontent.com/thim81/openapi-format/main/defaultFilter.json';
-    const validFilePath = __dirname + '/../defaultFilter.json';
+    const validRemoteFilePath = 'https://raw.githubusercontent.com/thim81/openapi-format/main/defaultSort.json';
+    const validFilePath = __dirname + '/../defaultSort.json';
 
-    const invalidRemoteFilePath = 'https://example.com/nonexistent-file.txt';
+    const invalidRemoteFileHttp = 'http://example.com/nonexistent-file.txt';
+    const invalidRemoteFileHttps = 'https://example.com/nonexistent-file.txt';
 
     test('should download remote file content successfully', async () => {
       const content = await getRemoteFile(validRemoteFilePath);
@@ -189,9 +190,23 @@ describe('openapi-format CLI file tests', () => {
       expect(content).toEqual(fileContent);
     });
 
-    test('should throw an error for nonexistent remote file', async () => {
+    test('should download remote file content successfully', async () => {
+      const content = await getRemoteFile(validRemoteFilePath);
+      const fileContent = fs.readFileSync(validFilePath, 'utf8');
+      expect(content).toEqual(fileContent);
+    });
+
+    test('should throw an error for https nonexistent remote file', async () => {
       try {
-        await getRemoteFile(invalidRemoteFilePath);
+        await getRemoteFile(invalidRemoteFileHttps);
+      } catch (err) {
+        expect(err.message).toMatch(/404 Not Found/);
+      }
+    });
+
+    test('should throw an error for http nonexistent remote file', async () => {
+      try {
+        await getRemoteFile(invalidRemoteFileHttp);
       } catch (err) {
         expect(err.message).toMatch(/404 Not Found/);
       }

--- a/test/yaml-filter-inverse-flags-flagsValues/customFilter.yaml
+++ b/test/yaml-filter-inverse-flags-flagsValues/customFilter.yaml
@@ -1,0 +1,4 @@
+inverseFlagValues:
+    - x-release: preview
+    - x-release: dev
+

--- a/test/yaml-filter-inverse-flags-flagsValues/input.yaml
+++ b/test/yaml-filter-inverse-flags-flagsValues/input.yaml
@@ -1,0 +1,828 @@
+openapi: 3.0.2
+servers:
+  - url: /v3
+info:
+  description: This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  version: 1.0.6-SNAPSHOT
+  title: Swagger Petstore - OpenAPI 3.0
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+  - name: store
+    description: Everything about your store
+    x-release: preview
+  - name: shops
+    description: Everything about your shops
+    x-release: live
+  - name: user
+    x-visibility: true
+    x-release: preview
+    description: Everything about your user
+  - name: groups
+    x-visibility: dev
+    x-release: preview
+    description: Everything about your group
+  - name: types
+    x-visibility: false
+    description: Everything about your type
+
+x-tagGroups:
+  - name: Pet Store
+    x-release: preview
+    tags:
+      - pet
+      - store
+  - name: Users
+    x-visibility: true
+    tags:
+      - user
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      x-release: preview
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        description: Create a new pet in the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Pet'
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: Update an existing pet by Id
+      operationId: updatePet
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        description: Update an existent pet in the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Pet'
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      x-visibility: true
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: false
+          explode: true
+          schema:
+            type: string
+            enum:
+              - available
+              - pending
+              - sold
+            default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      operationId: findPetsByTags
+      x-release: dev
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+  '/pet/{petId}':
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to return
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+        - api_key: []
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet that needs to be updated
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: name
+          in: query
+          description: Name of pet that needs to be updated
+          schema:
+            type: string
+        - name: status
+          in: query
+          description: Status of pet that needs to be updated
+          schema:
+            type: string
+      responses:
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+        - name: api_key
+          in: header
+          description: ''
+          required: false
+          schema:
+            type: string
+        - name: petId
+          in: path
+          description: Pet id to delete
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+  '/pet/{petId}/uploadImage':
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+        - name: petId
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: additionalMetadata
+          in: query
+          description: Additional Metadata
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiResponse'
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      x-swagger-router-controller: OrderController
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      description: Place a new order in the store
+      operationId: placeOrder
+      x-swagger-router-controller: OrderController
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '405':
+          description: Invalid input
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Order'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Order'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Order'
+  '/store/order/{orderId}':
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      x-swagger-router-controller: OrderController
+      description: For valid response try integer IDs with value <= 5 or > 10. Other values will generated exceptions
+      operationId: getOrderById
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of order that needs to be fetched
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Order'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      x-swagger-router-controller: OrderController
+      description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+        - name: orderId
+          in: path
+          description: ID of the order that needs to be deleted
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      responses:
+        default:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/User'
+        description: Created user object
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      description: Creates list of users with given input array
+      x-swagger-router-controller: UserController
+      operationId: createUsersWithListInput
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        default:
+          description: successful operation
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/User'
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+        - name: username
+          in: query
+          description: The user name for login
+          required: false
+          schema:
+            type: string
+        - name: password
+          in: query
+          description: The password for login in clear text
+          required: false
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+  '/user/{username}':
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+        - name: username
+          in: path
+          description: 'The name that needs to be fetched. Use user1 for testing. '
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/User'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Update user
+      x-swagger-router-controller: UserController
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+        - name: username
+          in: path
+          description: name that need to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        default:
+          description: successful operation
+      requestBody:
+        description: Update an existent user in the store
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/User'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/User'
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+        - name: username
+          in: path
+          description: The name that needs to be deleted
+          required: true
+          schema:
+            type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+components:
+  schemas:
+    Order:
+      x-swagger-router-model: io.swagger.petstore.model.Order
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+          example: approved
+        complete:
+          type: boolean
+      xml:
+        name: order
+      type: object
+    Customer:
+      x-release: dev
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 100000
+        username:
+          type: string
+          example: fehguy
+        address:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+          xml:
+            wrapped: true
+            name: addresses
+      xml:
+        name: customer
+      type: object
+    Address:
+      x-release: preview
+      properties:
+        street:
+          type: string
+          example: 437 Lytton
+        city:
+          type: string
+          example: Palo Alto
+        state:
+          type: string
+          example: CA
+        zip:
+          type: string
+          example: 94301
+      xml:
+        name: address
+      type: object
+    Category:
+      x-swagger-router-model: io.swagger.petstore.model.Category
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+      xml:
+        name: category
+      type: object
+    User:
+      x-swagger-router-model: io.swagger.petstore.model.User
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: 12345
+        phone:
+          type: string
+          example: 12345
+        userStatus:
+          type: integer
+          format: int32
+          example: 1
+          description: User Status
+      xml:
+        name: user
+      type: object
+    Tag:
+      x-swagger-router-model: io.swagger.petstore.model.Tag
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: tag
+      type: object
+    Pet:
+      x-swagger-router-model: io.swagger.petstore.model.Pet
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          $ref: '#/components/schemas/Category'
+        photoUrls:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            type: string
+            xml:
+              name: photoUrl
+        tags:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+            xml:
+              name: tag
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: pet
+      type: object
+    ApiResponse:
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+      xml:
+        name: '##default'
+      type: object
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+      description: List of user object
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          scopes:
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/test/yaml-filter-inverse-flags-flagsValues/options.yaml
+++ b/test/yaml-filter-inverse-flags-flagsValues/options.yaml
@@ -1,0 +1,4 @@
+verbose: true
+no-sort: true
+output: output.yaml
+filterFile: customFilter.yaml

--- a/test/yaml-filter-inverse-flags-flagsValues/output.yaml
+++ b/test/yaml-filter-inverse-flags-flagsValues/output.yaml
@@ -27,6 +27,7 @@ x-tagGroups:
   - name: Pet Store
     x-release: preview
     tags:
+      - pet
       - store
 paths:
   /pet:

--- a/test/yaml-filter-inverse-flags-flagsValues/output.yaml
+++ b/test/yaml-filter-inverse-flags-flagsValues/output.yaml
@@ -1,0 +1,149 @@
+openapi: 3.0.2
+servers:
+  - url: /v3
+info:
+  description: This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  version: 1.0.6-SNAPSHOT
+  title: Swagger Petstore - OpenAPI 3.0
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: store
+    description: Everything about your store
+    x-release: preview
+  - name: user
+    x-visibility: true
+    x-release: preview
+    description: Everything about your user
+  - name: groups
+    x-visibility: dev
+    x-release: preview
+    description: Everything about your group
+x-tagGroups:
+  - name: Pet Store
+    x-release: preview
+    tags:
+      - store
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      x-release: preview
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        description: Create a new pet in the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Pet'
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      operationId: findPetsByTags
+      x-release: dev
+      parameters:
+        - name: tags
+          in: query
+          description: Tags to filter by
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+components:
+  schemas:
+    Customer:
+      x-release: dev
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 100000
+        username:
+          type: string
+          example: fehguy
+        address:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+          xml:
+            wrapped: true
+            name: addresses
+      xml:
+        name: customer
+      type: object
+    Address:
+      x-release: preview
+      properties:
+        street:
+          type: string
+          example: 437 Lytton
+        city:
+          type: string
+          example: Palo Alto
+        state:
+          type: string
+          example: CA
+        zip:
+          type: string
+          example: 94301
+      xml:
+        name: address
+      type: object

--- a/test/yaml-filter-inverse-flags/customFilter.yaml
+++ b/test/yaml-filter-inverse-flags/customFilter.yaml
@@ -1,0 +1,4 @@
+inverseFlags:
+  - x-visibility
+  - x-stage
+

--- a/test/yaml-filter-inverse-flags/input.yaml
+++ b/test/yaml-filter-inverse-flags/input.yaml
@@ -1,0 +1,366 @@
+openapi: 3.0.2
+servers:
+  - url: /v3
+info:
+  description: This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  version: 1.0.6-SNAPSHOT
+  title: Swagger Petstore - OpenAPI 3.0
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: pet
+    description: Everything about your Pets
+  - name: store
+    description: Everything about your store
+  - name: user
+    x-visibility: true
+    description: Everything about your user
+x-tagGroups:
+  - name: Pet Store
+    x-version: 1
+    tags:
+      - pet
+      - store
+  - name: Users
+    x-visibility: true
+    tags:
+      - user
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      x-visibility: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        description: Create a new pet in the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Pet'
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      description: Update an existing pet by Id
+      operationId: updatePet
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        description: Update an existent pet in the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Pet'
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      x-stage: preview
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: false
+          explode: true
+          schema:
+            type: string
+            enum:
+              - available
+              - pending
+              - sold
+            default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+components:
+  schemas:
+    Order:
+      x-swagger-router-model: io.swagger.petstore.model.Order
+      x-doe: true
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+          example: approved
+        complete:
+          type: boolean
+      xml:
+        name: order
+      type: object
+    Customer:
+      x-visibility: true
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 100000
+        username:
+          type: string
+          example: fehguy
+        address:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+          xml:
+            wrapped: true
+            name: addresses
+      xml:
+        name: customer
+      type: object
+    Address:
+      x-stage: preview
+      properties:
+        street:
+          type: string
+          example: 437 Lytton
+        city:
+          type: string
+          example: Palo Alto
+        state:
+          type: string
+          example: CA
+        zip:
+          type: string
+          example: 94301
+      xml:
+        name: address
+      type: object
+    Category:
+      x-swagger-router-model: io.swagger.petstore.model.Category
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+      xml:
+        name: category
+      type: object
+    User:
+      x-swagger-router-model: io.swagger.petstore.model.User
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: 12345
+        phone:
+          type: string
+          example: 12345
+        userStatus:
+          type: integer
+          format: int32
+          example: 1
+          description: User Status
+      xml:
+        name: user
+      type: object
+    Tag:
+      x-swagger-router-model: io.swagger.petstore.model.Tag
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: tag
+      type: object
+    Pet:
+      x-swagger-router-model: io.swagger.petstore.model.Pet
+      required:
+        - name
+        - photoUrls
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          $ref: '#/components/schemas/Category'
+        photoUrls:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            type: string
+            xml:
+              name: photoUrl
+        tags:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            $ref: '#/components/schemas/Tag'
+            xml:
+              name: tag
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: pet
+      type: object
+    ApiResponse:
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+      xml:
+        name: '##default'
+      type: object
+  requestBodies:
+    Pet:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Pet'
+        application/xml:
+          schema:
+            $ref: '#/components/schemas/Pet'
+      description: Pet object that needs to be added to the store
+    UserArray:
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/User'
+      description: List of user object
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          scopes:
+            'write:pets': modify pets in your account
+            'read:pets': read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/test/yaml-filter-inverse-flags/options.yaml
+++ b/test/yaml-filter-inverse-flags/options.yaml
@@ -1,0 +1,4 @@
+verbose: true
+no-sort: true
+output: output.yaml
+filterFile: customFilter.yaml

--- a/test/yaml-filter-inverse-flags/output.yaml
+++ b/test/yaml-filter-inverse-flags/output.yaml
@@ -1,0 +1,144 @@
+openapi: 3.0.2
+servers:
+  - url: /v3
+info:
+  description: This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
+  version: 1.0.6-SNAPSHOT
+  title: Swagger Petstore - OpenAPI 3.0
+  termsOfService: 'http://swagger.io/terms/'
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: user
+    x-visibility: true
+    description: Everything about your user
+x-tagGroups:
+  - name: Users
+    x-visibility: true
+    tags:
+      - user
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      x-visibility: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '405':
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+      requestBody:
+        description: Create a new pet in the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/xml:
+            schema:
+              $ref: '#/components/schemas/Pet'
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/Pet'
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      x-stage: preview
+      parameters:
+        - name: status
+          in: query
+          description: Status values that need to be considered for filter
+          required: false
+          explode: true
+          schema:
+            type: string
+            enum:
+              - available
+              - pending
+              - sold
+            default: available
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Pet'
+        '400':
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - 'write:pets'
+            - 'read:pets'
+externalDocs:
+  description: Find out more about Swagger
+  url: 'http://swagger.io'
+components:
+  schemas:
+    Customer:
+      x-visibility: true
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 100000
+        username:
+          type: string
+          example: fehguy
+        address:
+          type: array
+          items:
+            $ref: '#/components/schemas/Address'
+          xml:
+            wrapped: true
+            name: addresses
+      xml:
+        name: customer
+      type: object
+    Address:
+      x-stage: preview
+      properties:
+        street:
+          type: string
+          example: 437 Lytton
+        city:
+          type: string
+          example: Palo Alto
+        state:
+          type: string
+          example: CA
+        zip:
+          type: string
+          example: 94301
+      xml:
+        name: address
+      type: object


### PR DESCRIPTION
This PR introduces the `inverseFlags` and `inverseFlagValues` option.

Both are a very aggressive filters, since it will only keep the elements where the flag or flag with the values are present.

For now, they focuss on inverse filtering for flags & flagValues for operations, components, tags, x-tagGroups elements.
The elements like info, servers remain untouched by the `inverseFlags` & `inverseFlagValues` filtering.