### PR TITLE
Convert - check node is object and not null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## unreleased
 
+- Convert - Check node is not null in traverse
+
 ## [1.22.0] - 2024-08-04
 
 - Sort - Added option to sort paths alphabetically or by tag (#119)

--- a/openapi-format.js
+++ b/openapi-format.js
@@ -57,7 +57,7 @@ async function openapiSort(oaObj, options) {
   // Recursive traverse through OpenAPI document
   traverse(jsonObj).forEach(function (node) {
 
-    if (typeof node === 'object') {
+    if (typeof node === 'object' && node !== null) {
 
       // Components sorting by alphabet
       if (this.parent && this.parent.key && this.path[0] === 'components' && this.parent.key === 'components'
@@ -885,7 +885,7 @@ async function openapiConvertVersion(oaObj, options) {
 
   // Recursive traverse through OpenAPI document for deprecated 3.0 properties
   traverse(jsonObj).forEach(function (node) {
-    if (typeof node === 'object') {
+    if (typeof node === 'object' && node !== null) {
       // Change components/schemas - properties
       if (node.type) {
         // Change type > nullable


### PR DESCRIPTION
The convert will fail when a null value is detected (cannot read property type of null)

Failing code:
` if (typeof node === 'object){`

because 

`typeof null === "object"` in javascript will return `true`

Example property:
```
  "type": "integer",
  "default": null,
  "maximum": 99999,
  "minimum": 1,
  "nullable": true
```