### PR TITLE
Fix CLI option typo in README

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -193,7 +193,7 @@ Options:
 | --no-sort            |               | don't sort the OpenAPI file                                                 | boolean      | FALSE                      | optional |
 | --keepComments       |               | don't remove the comments from the OpenAPI YAML file                        | boolean      | FALSE                      | optional |
 | --sortComponentsFile |               | sort the items of the components (schemas, parameters, ...) by alphabet     | path to file | defaultSortComponents.json | optional |
-| --no-bunlde          |               | don't bundle the local and remote $ref in the OpenAPI document              | boolean      | FALSE                      | optional |
+| --no-bundle          |               | don't bundle the local and remote $ref in the OpenAPI document              | boolean      | FALSE                      | optional |
 | --split              |               | split the OpenAPI document into a multi-file structure                      | boolean      | FALSE                      | optional |
 | --rename             |               | rename the OpenAPI title                                                    | string       |                            | optional |
 | --convertTo          |               | convert the OpenAPI document to OpenAPI version 3.1                         | string       |                            | optional |


### PR DESCRIPTION
## Summary
- correct the `--no-bunlde` option name to `--no-bundle` in README

## Testing
- `npm test` *(fails: ENETUNREACH for remote file tests)*

------
https://chatgpt.com/codex/tasks/task_e_683ff9eb7ba08321b4fdaadc84bd2c8f