### PR TITLE
fix: incorrect relative path generation in $ref during OpenAPI document splitting

### DIFF
--- a/utils/split.js
+++ b/utils/split.js
@@ -60,7 +60,7 @@ async function writeComponents(components, options) {
       const filePath = path.join(fileDir, `${componentName}.${ext}`);
 
       // Update any component references within components
-      const updatedComponent = convertComponentsToRef(components[componentType][componentName], ext, 'components');
+      const updatedComponent = convertComponentsToRef(components[componentType][componentName], ext, path.join('components', componentType));
 
       // Write each component (schema, parameter, etc.) to its own YAML file
       await writeFile(filePath, updatedComponent, options);


### PR DESCRIPTION
**Problem Description**  
When using the `openapiSplit()` function to split an OpenAPI document into multiple files, component references in `$ref` would generate incorrect relative paths, causing `parseFile()` to fail during bundling.  
**Example error:**  
```
Cannot resolve: test-split/components/schemas/schemas/NotificationPreferences.json
```
Note the duplicate `schemas` directory.

***

**Root Cause**  
In `utils/split.js` (line 63), the `writeComponents()` function passed an incorrect `currentFileDir` parameter to `convertComponentsToRef()`:

**Before (incorrect):**  
```javascript
convertComponentsToRef(components[componentType][componentName], ext, 'components')
```

- A component like `User.json` in `components/schemas/` referencing `NotificationPreferences.json` would yield:
    - **Expected:** `"NotificationPreferences.json"`
    - **Actual:** `"schemas/NotificationPreferences.json"`
- This resulted in bundler looking for `components/schemas/schemas/NotificationPreferences.json` (extra `schemas` in the path).

***

**Solution**  
**After (fixed):**  
```javascript
convertComponentsToRef(components[componentType][componentName], ext, path.join('components', componentType))
```
- Now the function receives the full directory path (e.g., `components/schemas`), producing correct relative paths.

***

**Test Results**

- ✅ **All existing tests pass** (no regression)
- ✅ **Split operation works correctly** (proper file structure created)
- ✅ **Bundle operation works correctly** (all `$ref` resolved)
- ✅ **End-to-end verification:** Large documents can be split & bundled

***

**Testing Steps**

1. **Split Test:**
    ```bash
    node -e "const {openapiSplit, parseFile} = require('./openapi-format.js');
    parseFile('./test-spec.json').then(obj => openapiSplit(obj, {output: './test-split/api.json'}))"
    ```
2. **Bundle Test:**
    ```bash
    node -e "const {parseFile} = require('./openapi-format.js');
    parseFile('./test-split/api.json', {bundle: true}).then(obj => console.log('Success!'))"
    ```

***

**Impact**

- **Fixes broken functionality:** Split documents can be properly bundled  
- **No breaking changes:** Existing functionality intact  
- **Improves reliability:** Corrects path resolution for complex references  
- **Future-proof:** Ensures path generation works for all component types

***

**Summary**  
This PR resolves a critical bug with `$ref` resolution after splitting OpenAPI documents, improving reliability and ensuring smooth end-to-end workflows.

[1](https://github.com/thim81/openapi-format/compare/main...tark-ai:openapi-format:main)