### PR TITLE
fix(overlays): copy `update` object to avoid applying to references

### DIFF
--- a/test/overlay-previous-overlay/input.yaml
+++ b/test/overlay-previous-overlay/input.yaml
@@ -1,0 +1,17 @@
+type: object
+properties:
+  parent:
+    type: object
+    properties:
+      one:
+        type: object
+        properties:
+          child: {}
+      two:
+        type: object
+        properties:
+          child: {}
+      three:
+        type: object
+        properties:
+          child: {}

--- a/test/overlay-previous-overlay/options.yaml
+++ b/test/overlay-previous-overlay/options.yaml
@@ -1,0 +1,2 @@
+output: output.yaml
+overlayFile: overlay.yaml

--- a/test/overlay-previous-overlay/output.yaml
+++ b/test/overlay-previous-overlay/output.yaml
@@ -1,0 +1,77 @@
+type: object
+properties:
+  parent:
+    type: object
+    properties:
+      one:
+        type: object
+        properties:
+          child:
+            oneOf:
+              - type: object
+                properties:
+                  type:
+                    const: a
+                  a:
+                    type: object
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            const: c
+                          c:
+                            type: object
+              - type: object
+                properties:
+                  type:
+                    const: b
+                  b:
+                    type: object
+      two:
+        type: object
+        properties:
+          child:
+            oneOf:
+              - type: object
+                properties:
+                  type:
+                    const: a
+                  a:
+                    type: object
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            const: c
+                          c:
+                            type: object
+              - type: object
+                properties:
+                  type:
+                    const: b
+                  b:
+                    type: object
+      three:
+        type: object
+        properties:
+          child:
+            oneOf:
+              - type: object
+                properties:
+                  type:
+                    const: a
+                  a:
+                    type: object
+                    oneOf:
+                      - type: object
+                        properties:
+                          type:
+                            const: c
+                          c:
+                            type: object
+              - type: object
+                properties:
+                  type:
+                    const: b
+                  b:
+                    type: object

--- a/test/overlay-previous-overlay/overlay.yaml
+++ b/test/overlay-previous-overlay/overlay.yaml
@@ -1,0 +1,32 @@
+actions:
+
+# apply an overlay to add an object from this overlay into the original OpenAPI schema
+# this should be applied as a copy to each target, not a reference
+  - target: $..child
+    update:
+      oneOf:
+        - type: object
+          properties:
+            type:
+              const: a
+            a:
+              type: object
+        - type: object
+          properties:
+            type:
+              const: b
+            b:
+              type: object
+
+# apply a further overlay to the above overlaid object
+# as the above overlaid object should be a copy, we shouldn't keep
+# adding the overlay multiple times to the same referenced object
+  - target: $..child.oneOf[0].properties.a
+    update:
+      oneOf:
+        - type: object
+          properties:
+            type:
+              const: c
+            c:
+              type: object

--- a/utils/overlay.js
+++ b/utils/overlay.js
@@ -60,7 +60,9 @@ async function openapiOverlay(oaObj, options) {
       // Handle update actions
       targets.forEach(node => {
         if (node.parent && node.key !== undefined) {
-          node.parent[node.key] = deepMerge(node.value, update);
+          // make a copy of the update object any further updates aren't applied
+          // multiple times to the same object
+          node.parent[node.key] = deepMerge(node.value, structuredClone(update));
         }
       });
     }


### PR DESCRIPTION
Using OpenAPI overlays, when an `update` applies to several targets the `update` object/source is applied by reference to all targets.

This means that if you subsequently try to make a further `update` to only one of these targets, this update will be applied to all of the previously applied targets (via the reference)

This PR adds a `structuredClone` to the `update` object which makes a deep copy/clone of it before applying, which I think is the correct fix for the issue. (Note: `structuredClone` is available from node 17)

---

I've included a rough reproduction which is the easiest way to see the problem. If you revert the fix I've applied here you will see that the output of the overlay produces something like the following i.e. the second `update` is applied three times.


```yaml
...
a:
  type: object
  oneOf:
    - type: object
      properties:
        type:
          const: c
        c:
          type: object
    - type: object
      properties:
        type:
          const: c
        c:
          type: object
    - type: object
      properties:
        type:
          const: c
        c:
          type: object
...
```

I've also added some comments in the reproduction to help understand the issue, I'd be happy to remove these before merge if you don't want these to stay in there.

Let me know if you have any questions on the above 👍 