### PR TITLE
refactor: replace stoplight/yaml with yaml (eemeli)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.30.1",
       "license": "MIT",
       "dependencies": {
-        "@stoplight/yaml": "^4.3.0",
         "api-ref-bundler": "^0.5.0",
         "case-anything": "2.1.10",
         "jsonpathly": "^3.0.0",
-        "neotraverse": "^0.6.18"
+        "neotraverse": "^0.6.18",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "openapi-format": "bin/cli.js"
@@ -1056,45 +1056,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "node_modules/@stoplight/ordered-object-literal": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.5.tgz",
-      "integrity": "sha512-COTiuCU5bgMUtbIFBuyyh2/yVVzlr5Om0v5utQDgBCuQUOPgU1DwoffkTfg4UBQOvByi5foF4w4T+H9CoRe5wg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@stoplight/types": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
-      "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
-      "dependencies": {
-        "@types/json-schema": "^7.0.4",
-        "utility-types": "^3.10.0"
-      },
-      "engines": {
-        "node": "^12.20 || >=14.13"
-      }
-    },
-    "node_modules/@stoplight/yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.3.0.tgz",
-      "integrity": "sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==",
-      "dependencies": {
-        "@stoplight/ordered-object-literal": "^1.0.5",
-        "@stoplight/types": "^14.1.1",
-        "@stoplight/yaml-ast-parser": "0.0.50",
-        "tslib": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=10.8"
-      }
-    },
-    "node_modules/@stoplight/yaml-ast-parser": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.50.tgz",
-      "integrity": "sha512-Pb6M8TDO9DtSVla9yXSTAxmo9GVEouq5P40DWXdOie69bXogZTkgvopCq+yEvTMA0F6PEvdJmbtTV3ccIp11VQ=="
-    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -1177,11 +1138,6 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "node_modules/@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/node": {
       "version": "25.5.0",
@@ -4095,7 +4051,9 @@
     "node_modules/tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "optional": true
     },
     "node_modules/type-detect": {
       "version": "4.0.8",
@@ -4205,14 +4163,6 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
-    },
-    "node_modules/utility-types": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
-      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw==",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/v8-to-istanbul": {
@@ -4388,6 +4338,21 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -5216,36 +5181,6 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
-    "@stoplight/ordered-object-literal": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@stoplight/ordered-object-literal/-/ordered-object-literal-1.0.5.tgz",
-      "integrity": "sha512-COTiuCU5bgMUtbIFBuyyh2/yVVzlr5Om0v5utQDgBCuQUOPgU1DwoffkTfg4UBQOvByi5foF4w4T+H9CoRe5wg=="
-    },
-    "@stoplight/types": {
-      "version": "14.1.1",
-      "resolved": "https://registry.npmjs.org/@stoplight/types/-/types-14.1.1.tgz",
-      "integrity": "sha512-/kjtr+0t0tjKr+heVfviO9FrU/uGLc+QNX3fHJc19xsCNYqU7lVhaXxDmEID9BZTjG+/r9pK9xP/xU02XGg65g==",
-      "requires": {
-        "@types/json-schema": "^7.0.4",
-        "utility-types": "^3.10.0"
-      }
-    },
-    "@stoplight/yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@stoplight/yaml/-/yaml-4.3.0.tgz",
-      "integrity": "sha512-JZlVFE6/dYpP9tQmV0/ADfn32L9uFarHWxfcRhReKUnljz1ZiUM5zpX+PH8h5CJs6lao3TuFqnPm9IJJCEkE2w==",
-      "requires": {
-        "@stoplight/ordered-object-literal": "^1.0.5",
-        "@stoplight/types": "^14.1.1",
-        "@stoplight/yaml-ast-parser": "0.0.50",
-        "tslib": "^2.2.0"
-      }
-    },
-    "@stoplight/yaml-ast-parser": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@stoplight/yaml-ast-parser/-/yaml-ast-parser-0.0.50.tgz",
-      "integrity": "sha512-Pb6M8TDO9DtSVla9yXSTAxmo9GVEouq5P40DWXdOie69bXogZTkgvopCq+yEvTMA0F6PEvdJmbtTV3ccIp11VQ=="
-    },
     "@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -5320,11 +5255,6 @@
       "requires": {
         "@types/istanbul-lib-report": "*"
       }
-    },
-    "@types/json-schema": {
-      "version": "7.0.15",
-      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "@types/node": {
       "version": "25.5.0",
@@ -7250,7 +7180,9 @@
     "tslib": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
-      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "optional": true
     },
     "type-detect": {
       "version": "4.0.8",
@@ -7313,11 +7245,6 @@
         "escalade": "^3.2.0",
         "picocolors": "^1.1.1"
       }
-    },
-    "utility-types": {
-      "version": "3.11.0",
-      "resolved": "https://registry.npmjs.org/utility-types/-/utility-types-3.11.0.tgz",
-      "integrity": "sha512-6Z7Ma2aVEWisaL6TvBCy7P8rm2LQoPv6dJ7ecIaIixHcwfbJ0x7mWdbcwlIM5IGQxPZSFYeqRCqlOOeKoJYMkw=="
     },
     "v8-to-istanbul": {
       "version": "9.3.0",
@@ -7439,6 +7366,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true
+    },
+    "yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="
     },
     "yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "release": "npx np --branch main"
   },
   "dependencies": {
-    "@stoplight/yaml": "^4.3.0",
+    "yaml": "^2.8.3",
     "api-ref-bundler": "^0.5.0",
     "case-anything": "2.1.10",
     "jsonpathly": "^3.0.0",

--- a/readme.md
+++ b/readme.md
@@ -1699,18 +1699,6 @@ For handling AsyncAPI documents, we have created a separate
 package [asyncapi-format](https://github.com/thim81/asyncapi-format) to allow customisation specific for AsyncAPI
 use-cases.
 
-## Stoplight Studio
-
-We have adopted the YAML parsing style from [Stoplight Studio](https://stoplight.io/studio/), by leveraging
-the [@stoplight/yaml](https://www.npmjs.com/package/@stoplight/yaml) package for handling the parsing of OpenAPI YAML
-files.
-
-By using the Stoplight YAML parsing, the results will be slightly different from when using a normal YAML parsing
-library, like [js-to-yaml](https://www.npmjs.com/package/js-yaml). We appreciate the Stoplight Studio tool, since it is
-an excellent GUI for working with OpenAPI documents for non-OpenAPI experts who will be contributing changes. By
-adopting the Stoplight Studio YAML parsing, the potential risk of merge conflicts will be lowered, which is the main
-reason why we opted for using the @stoplight/yaml package.
-
 ## Credits
 
 This package is inspired by

--- a/test/_split/snap.yaml
+++ b/test/_split/snap.yaml
@@ -4,12 +4,12 @@ info:
   version: 1.0.0
   description: A compact version of the Train Travel API
 paths:
-  '/stations/{station_id}':
-    $ref: 'paths/stations_{station_id}.yaml'
+  /stations/{station_id}:
+    $ref: paths/stations_{station_id}.yaml
 components:
   schemas:
     Station:
-      $ref: "components/schemas/Station.yaml"
+      $ref: components/schemas/Station.yaml
   parameters:
     StationId:
-      $ref: "components/parameters/StationId.yaml"
+      $ref: components/parameters/StationId.yaml

--- a/test/_split/snap_station.yaml
+++ b/test/_split/snap_station.yaml
@@ -2,13 +2,13 @@ get:
   summary: Get station information
   operationId: getStation
   parameters:
-    - $ref: "../components/parameters/StationId.yaml"
+    - $ref: ../components/parameters/StationId.yaml
   responses:
     '200':
       description: Successful operation
       content:
         application/json:
           schema:
-            $ref: "../components/schemas/Station.yaml"
+            $ref: ../components/schemas/Station.yaml
     '404':
       description: Station not found

--- a/test/json-custom-yaml/output.yaml
+++ b/test/json-custom-yaml/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     put:
@@ -91,8 +91,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -131,8 +131,8 @@ paths:
       description: Multiple status values can be provided with comma separated strings
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
 components:
@@ -337,10 +337,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -350,7 +350,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/json-default-yaml/output.yaml
+++ b/test/json-default-yaml/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     put:
@@ -91,8 +91,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -131,8 +131,8 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
 components:
@@ -337,10 +337,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -350,7 +350,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/overlay-combi/output.yaml
+++ b/test/overlay-combi/output.yaml
@@ -5,7 +5,7 @@ info:
   description: An updated description
   contact:
     name: Support
-    url: 'https://example.com/contact'
+    url: https://example.com/contact
 servers:
-  - url: 'https://api.new-example.com'
+  - url: https://api.new-example.com
     description: New server

--- a/test/overlay-extends-remote/output.yaml
+++ b/test/overlay-extends-remote/output.yaml
@@ -3,5 +3,5 @@ info:
   title: Original API
   version: 1.0.0
 servers:
-  - url: 'https://api.example.com'
+  - url: https://api.example.com
     description: Default server

--- a/test/overlay-params/output.yaml
+++ b/test/overlay-params/output.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.1
 info:
   title: Datasource API
   description: API to work with Datasources.
-  termsOfService: 'urn:tos'''
+  termsOfService: urn:tos'
 paths:
   /timeseries:
     get:

--- a/test/overlay-preserve-required/output.yaml
+++ b/test/overlay-preserve-required/output.yaml
@@ -31,11 +31,11 @@ components:
       properties:
         type:
           description: A URI reference that identifies the problem type
-          example: 'https://example.com/probs/permissions'
+          example: https://example.com/probs/permissions
           format: uri
           type: string
         title:
-          description: 'A short, human-readable summary of the problem type'
+          description: A short, human-readable summary of the problem type
           example: You do not have permissions to perform this action
           type: string
         status:
@@ -50,6 +50,6 @@ components:
           type: string
         instance:
           description: A URI reference that identifies the specific occurrence of the problem
-          example: 'https://example.com/account/12345/message/delete'
+          example: https://example.com/account/12345/message/delete
           format: uri
           type: string

--- a/test/util-file.test.js
+++ b/test/util-file.test.js
@@ -15,7 +15,7 @@ const {
   detectFormat,
   analyzeOpenApi
 } = require('../utils/file');
-const yaml = require('@stoplight/yaml');
+const yaml = require('yaml');
 const {describe} = require('@jest/globals');
 
 describe('openapi-format CLI file tests', () => {
@@ -124,7 +124,7 @@ describe('openapi-format CLI file tests', () => {
 
       const result = await stringify(obj, options);
 
-      const expectedYAML = yaml.safeStringify(obj, {lineWidth: 80});
+      const expectedYAML = yaml.stringify(obj, {lineWidth: 80, singleQuote: true});
       expect(result).toEqual(expectedYAML);
     });
 
@@ -144,7 +144,7 @@ describe('openapi-format CLI file tests', () => {
 
       const result = await stringify(obj, options);
 
-      const expectedYAML = yaml.safeStringify(obj, {lineWidth: Infinity});
+      const expectedYAML = yaml.stringify(obj, {lineWidth: 0, singleQuote: true});
       expect(result).toEqual(expectedYAML);
     });
 
@@ -154,7 +154,7 @@ describe('openapi-format CLI file tests', () => {
 
       const result = await stringify(obj, options);
 
-      const expectedYAML = yaml.safeStringify(obj, {lineWidth: Infinity});
+      const expectedYAML = yaml.stringify(obj, {lineWidth: 0, singleQuote: true});
       expect(result).toEqual(expectedYAML);
     });
 
@@ -192,6 +192,12 @@ describe('openapi-format CLI file tests', () => {
       const invalidString = '#name 1John\nage 30#'; // Invalid YAML
       const result = await parseString(invalidString, {format: 'yaml'});
       expect(result).toBeInstanceOf(SyntaxError);
+    });
+
+    it('should quote unquoted $ref value starting with #', async () => {
+      const yamlString = 'schema:\n  $ref: #/components/schemas/Example';
+      const result = await parseString(yamlString);
+      expect(result).toEqual({schema: {$ref: '#/components/schemas/Example'}});
     });
   });
 
@@ -390,10 +396,10 @@ describe('openapi-format CLI file tests', () => {
   });
 
   describe('addQuotesToRefInString function', () => {
-    test('should add " quotes to $ref in string', () => {
+    test('should add \' quotes to $ref in string', () => {
       const input = '$ref: #/components/schemas/Example';
       const output = addQuotesToRefInString(input);
-      expect(output).toBe('$ref: "#/components/schemas/Example"');
+      expect(output).toBe("$ref: '#/components/schemas/Example'");
     });
 
     test('should keep double quotes to $ref in string', () => {

--- a/test/yaml-big-numbers/output.yaml
+++ b/test/yaml-big-numbers/output.yaml
@@ -31,9 +31,9 @@ components:
   examples:
     Test1:
       value:
-        location: '10.12345678912345, 10.12345678912345'
+        location: 10.12345678912345, 10.12345678912345
         test_property: test
     Test2:
       value:
-        location: '10.12345678912345, 10.12345678912345'
+        location: 10.12345678912345, 10.12345678912345
         test_property: test

--- a/test/yaml-casing-component-keys/output.yaml
+++ b/test/yaml-casing-component-keys/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -66,8 +66,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /PetModel/findByStatus:
@@ -97,11 +97,11 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -131,8 +131,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -156,8 +156,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -183,8 +183,8 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/order:
@@ -215,7 +215,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -477,13 +477,13 @@ components:
     SampleExampleReports:
       value:
         id: bbadbeef-b3ab-40af-b05c-c0ffee6544cd
-        created: '2020-06-19T12:01:03.456Z'
-        lastAction: '2020-06-19T12:06:03.456Z'
+        created: 2020-06-19T12:01:03.456Z
+        lastAction: 2020-06-19T12:06:03.456Z
         status: Succeeded
         type: ListExport
-        resourceLocation: 'https://customername.example/export'
+        resourceLocation: https://customername.example/export
         properties:
-          reportLocation: 'https://customername.example/reports/ABC-123-DEF-456'
+          reportLocation: https://customername.example/reports/ABC-123-DEF-456
     SampleSendNotification:
       value:
         - reference: 1234567ABC
@@ -491,15 +491,15 @@ components:
             deviceToken: 1234567890AZERTYUIOP
             provider: apple
           content:
-            title: 'Hello world, content title'
-            message: 'Hello world, content message'
+            title: Hello world, content title
+            message: Hello world, content message
             badge: null
             sound: null
             buttons: []
             pushType: 2
             inAppNotification:
-              title: 'Hello world, inAppNotification title'
-              body: 'Hello world, inAppNotification body'
+              title: Hello world, inAppNotification title
+              body: Hello world, inAppNotification body
             expirationdate: null
             data:
               SMLTR_DEL_STATE: '2'
@@ -600,10 +600,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -629,7 +629,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-casing-component-parameters-keys/output.yaml
+++ b/test/yaml-casing-component-parameters-keys/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -66,8 +66,8 @@ paths:
           description: Invalid input
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /PetModel/findByStatus:
@@ -97,11 +97,11 @@ paths:
       security:
         - ApiKey: []
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -131,8 +131,8 @@ paths:
       security:
         - ApiKey: []
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -156,8 +156,8 @@ paths:
           description: Invalid input
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -183,8 +183,8 @@ paths:
           description: Invalid pet value
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/order:
@@ -215,7 +215,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -477,13 +477,13 @@ components:
     sample-example-reports:
       value:
         id: bbadbeef-b3ab-40af-b05c-c0ffee6544cd
-        created: '2020-06-19T12:01:03.456Z'
-        lastAction: '2020-06-19T12:06:03.456Z'
+        created: 2020-06-19T12:01:03.456Z
+        lastAction: 2020-06-19T12:06:03.456Z
         status: Succeeded
         type: ListExport
-        resourceLocation: 'https://customername.example/export'
+        resourceLocation: https://customername.example/export
         properties:
-          reportLocation: 'https://customername.example/reports/ABC-123-DEF-456'
+          reportLocation: https://customername.example/reports/ABC-123-DEF-456
     sample-send-notification:
       value:
         - reference: 1234567ABC
@@ -491,15 +491,15 @@ components:
             deviceToken: 1234567890AZERTYUIOP
             provider: apple
           content:
-            title: 'Hello world, content title'
-            message: 'Hello world, content message'
+            title: Hello world, content title
+            message: Hello world, content message
             badge: null
             sound: null
             buttons: []
             pushType: 2
             inAppNotification:
-              title: 'Hello world, inAppNotification title'
-              body: 'Hello world, inAppNotification body'
+              title: Hello world, inAppNotification title
+              body: Hello world, inAppNotification body
             expirationdate: null
             data:
               SMLTR_DEL_STATE: '2'
@@ -607,10 +607,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     ApiKey:
       type: apiKey
       name: api_key
@@ -636,7 +636,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-casing-operationId/output.yaml
+++ b/test/yaml-casing-operationId/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /PetModel/findByStatus:
@@ -81,8 +81,8 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
 components:
@@ -166,10 +166,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -178,14 +178,14 @@ components:
     sample-script-output-failure:
       value:
         operationId: 7e24fadb-c31a-4b47-a8bf-4996900fc6c9
-        created: '2020-06-19T12:01:03.456Z'
-        lastAction: '2020-06-19T12:06:03.456Z'
+        created: 2020-06-19T12:01:03.456Z
+        lastAction: 2020-06-19T12:06:03.456Z
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-casing-parameters/output.yaml
+++ b/test/yaml-casing-parameters/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -74,8 +74,8 @@ paths:
           description: Invalid input
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /PetModel/findByStatus:
@@ -104,11 +104,11 @@ paths:
       security:
         - ApiKey: []
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -145,8 +145,8 @@ paths:
       security:
         - ApiKey: []
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -176,8 +176,8 @@ paths:
           description: Invalid input
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -203,8 +203,8 @@ paths:
           description: Invalid pet value
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/order:
@@ -235,7 +235,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -571,13 +571,13 @@ components:
     sample-example-reports:
       value:
         id: bbadbeef-b3ab-40af-b05c-c0ffee6544cd
-        created: '2020-06-19T12:01:03.456Z'
-        lastAction: '2020-06-19T12:06:03.456Z'
+        created: 2020-06-19T12:01:03.456Z
+        lastAction: 2020-06-19T12:06:03.456Z
         status: Succeeded
         type: ListExport
-        resourceLocation: 'https://customername.example/export'
+        resourceLocation: https://customername.example/export
         properties:
-          reportLocation: 'https://customername.example/reports/ABC-123-DEF-456'
+          reportLocation: https://customername.example/reports/ABC-123-DEF-456
     sample-send-notification:
       value:
         - reference: 1234567ABC
@@ -585,15 +585,15 @@ components:
             deviceToken: 1234567890AZERTYUIOP
             provider: apple
           content:
-            title: 'Hello world, content title'
-            message: 'Hello world, content message'
+            title: Hello world, content title
+            message: Hello world, content message
             badge: null
             sound: null
             buttons: []
             pushType: 2
             inAppNotification:
-              title: 'Hello world, inAppNotification title'
-              body: 'Hello world, inAppNotification body'
+              title: Hello world, inAppNotification title
+              body: Hello world, inAppNotification body
             expirationdate: null
             data:
               SMLTR_DEL_STATE: '2'
@@ -676,10 +676,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     ApiKey:
       type: apiKey
       name: api_key
@@ -705,7 +705,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-casing-properties/output.yaml
+++ b/test/yaml-casing-properties/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -66,8 +66,8 @@ paths:
           description: Invalid input
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /PetModel/findByStatus:
@@ -96,11 +96,11 @@ paths:
       security:
         - ApiKey: []
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -130,8 +130,8 @@ paths:
       security:
         - ApiKey: []
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -161,8 +161,8 @@ paths:
           description: Invalid input
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -188,8 +188,8 @@ paths:
           description: Invalid pet value
       security:
         - PetstoreAuth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/order:
@@ -220,7 +220,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -556,13 +556,13 @@ components:
     sample-example-reports:
       value:
         id: bbadbeef-b3ab-40af-b05c-c0ffee6544cd
-        created: '2020-06-19T12:01:03.456Z'
-        lastAction: '2020-06-19T12:06:03.456Z'
+        created: 2020-06-19T12:01:03.456Z
+        lastAction: 2020-06-19T12:06:03.456Z
         status: Succeeded
         type: ListExport
-        resourceLocation: 'https://customername.example/export'
+        resourceLocation: https://customername.example/export
         properties:
-          reportLocation: 'https://customername.example/reports/ABC-123-DEF-456'
+          reportLocation: https://customername.example/reports/ABC-123-DEF-456
     sample-send-notification:
       value:
         - reference: 1234567ABC
@@ -570,15 +570,15 @@ components:
             deviceToken: 1234567890AZERTYUIOP
             provider: apple
           content:
-            title: 'Hello world, content title'
-            message: 'Hello world, content message'
+            title: Hello world, content title
+            message: Hello world, content message
             badge: null
             sound: null
             buttons: []
             pushType: 2
             inAppNotification:
-              title: 'Hello world, inAppNotification title'
-              body: 'Hello world, inAppNotification body'
+              title: Hello world, inAppNotification title
+              body: Hello world, inAppNotification body
             expirationdate: null
             data:
               SMLTR_DEL_STATE: '2'
@@ -661,10 +661,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     ApiKey:
       type: apiKey
       name: api_key
@@ -690,7 +690,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-casing/output.yaml
+++ b/test/yaml-casing/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -74,8 +74,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /PetModel/findByStatus:
@@ -104,11 +104,11 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: get_pet_by_id
       summary: Find pet by ID
@@ -145,8 +145,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -176,8 +176,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -203,8 +203,8 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/order:
@@ -235,7 +235,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: get_user_by_name
       summary: Get user by user name
@@ -571,13 +571,13 @@ components:
     SampleExampleReports:
       value:
         id: bbadbeef-b3ab-40af-b05c-c0ffee6544cd
-        created: '2020-06-19T12:01:03.456Z'
-        lastAction: '2020-06-19T12:06:03.456Z'
+        created: 2020-06-19T12:01:03.456Z
+        lastAction: 2020-06-19T12:06:03.456Z
         status: Succeeded
         type: ListExport
-        resourceLocation: 'https://customername.example/export'
+        resourceLocation: https://customername.example/export
         properties:
-          reportLocation: 'https://customername.example/reports/ABC-123-DEF-456'
+          reportLocation: https://customername.example/reports/ABC-123-DEF-456
     SampleSendNotification:
       value:
         - reference: 1234567ABC
@@ -585,15 +585,15 @@ components:
             deviceToken: 1234567890AZERTYUIOP
             provider: apple
           content:
-            title: 'Hello world, content title'
-            message: 'Hello world, content message'
+            title: Hello world, content title
+            message: Hello world, content message
             badge: null
             sound: null
             buttons: []
             pushType: 2
             inAppNotification:
-              title: 'Hello world, inAppNotification title'
-              body: 'Hello world, inAppNotification body'
+              title: Hello world, inAppNotification title
+              body: Hello world, inAppNotification body
             expirationdate: null
             data:
               SMLTR_DEL_STATE: '2'
@@ -676,10 +676,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -705,7 +705,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-convert-3.0-3.1/output.yaml
+++ b/test/yaml-convert-3.0-3.1/output.yaml
@@ -13,12 +13,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
@@ -44,8 +44,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -87,8 +87,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -149,14 +149,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -186,9 +186,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -220,8 +220,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -251,8 +251,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -278,9 +278,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -310,8 +310,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream: {}
@@ -363,7 +363,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -524,7 +524,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -617,7 +617,7 @@ webhooks:
           description: Return a 200 status to indicate that the data was received successfully
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -852,10 +852,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-convert-3.0-3.2/output.yaml
+++ b/test/yaml-convert-3.0-3.2/output.yaml
@@ -3,7 +3,7 @@ info:
   title: Minimal 3.0 with 3.1 upgrade hints
   version: 1.0.0
 servers:
-  - url: 'https://api.example.com'
+  - url: https://api.example.com
 paths:
   /items:
     get:

--- a/test/yaml-convert-3.1-3.2/output.yaml
+++ b/test/yaml-convert-3.1-3.2/output.yaml
@@ -3,7 +3,7 @@ info:
   title: Minimal 3.1 (designed for 3.2 migration)
   version: 1.0.0
 servers:
-  - url: 'https://api.example.com'
+  - url: https://api.example.com
 tags:
   - name: items
     description: Operations on items

--- a/test/yaml-custom-3.1/output.yaml
+++ b/test/yaml-custom-3.1/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     put:
@@ -91,8 +91,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -131,8 +131,8 @@ paths:
       description: Multiple status values can be provided with comma separated strings
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
@@ -165,14 +165,14 @@ paths:
           description: Invalid tag value
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       parameters:
         - required: true
@@ -202,8 +202,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -233,8 +233,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -260,11 +260,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -298,8 +298,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -350,7 +350,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       parameters:
         - required: true
@@ -511,7 +511,7 @@ paths:
       description: ''
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       parameters:
         - required: true
@@ -816,10 +816,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -829,4 +829,4 @@ tags:
     description: Everything about your Pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-custom/output.yaml
+++ b/test/yaml-custom/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     put:
@@ -91,8 +91,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -131,8 +131,8 @@ paths:
       description: Multiple status values can be provided with comma separated strings
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
@@ -165,14 +165,14 @@ paths:
           description: Invalid tag value
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       parameters:
         - required: true
@@ -202,8 +202,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -233,8 +233,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -260,11 +260,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -298,8 +298,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -350,7 +350,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       parameters:
         - required: true
@@ -512,7 +512,7 @@ paths:
       description: ''
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       parameters:
         - required: true
@@ -795,10 +795,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -808,7 +808,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-default-bug-examples-properties/output.yaml
+++ b/test/yaml-default-bug-examples-properties/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     put:
@@ -91,8 +91,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -131,15 +131,15 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
     get:
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       parameters:
         - name: tags
           in: query
@@ -168,11 +168,11 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -202,8 +202,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -233,8 +233,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -260,11 +260,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -298,8 +298,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -350,7 +350,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       operationId: getOrderById
       summary: Find purchase order by ID
@@ -510,7 +510,7 @@ paths:
           description: successful operation
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -773,13 +773,13 @@ components:
     sample-example-reports:
       value:
         id: bbadbeef-b3ab-40af-b05c-c0ffee6544cd
-        created: '2020-06-19T12:01:03.456Z'
-        lastAction: '2020-06-19T12:06:03.456Z'
+        created: 2020-06-19T12:01:03.456Z
+        lastAction: 2020-06-19T12:06:03.456Z
         status: Succeeded
         type: ListExport
-        resourceLocation: 'https://customername.example/export'
+        resourceLocation: https://customername.example/export
         properties:
-          reportLocation: 'https://customername.example/reports/ABC-123-DEF-456'
+          reportLocation: https://customername.example/reports/ABC-123-DEF-456
     sample-send-notification:
       value:
         - reference: 1234567ABC
@@ -787,15 +787,15 @@ components:
             deviceToken: 1234567890AZERTYUIOP
             provider: apple
           content:
-            title: 'Hello world, content title'
-            message: 'Hello world, content message'
+            title: Hello world, content title
+            message: Hello world, content message
             badge: null
             sound: null
             buttons: []
             pushType: 2
             inAppNotification:
-              title: 'Hello world, inAppNotification title'
-              body: 'Hello world, inAppNotification body'
+              title: Hello world, inAppNotification title
+              body: Hello world, inAppNotification body
             expirationdate: null
             data:
               SMLTR_DEL_STATE: '2'
@@ -809,7 +809,7 @@ components:
         - id: 0149531b-fac2-476f-ab71-f29bc9030582d
           source: mobile/sdk/device/6fa2d7d5-b374-4c42-8e1f-e05bac6136b4
           type: mobile.sdk.events.custom
-          time: '2022-03-15T14:17:32.7430000Z'
+          time: 2022-03-15T14:17:32.7430000Z
           specversion: '1.0'
           dataschema: '#/events/mobilesdk/customevent/v1'
           datacontenttype: application/json
@@ -845,10 +845,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -858,7 +858,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-default-bug-nested-properties/output.yaml
+++ b/test/yaml-default-bug-nested-properties/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     put:
@@ -91,8 +91,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -131,15 +131,15 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
     get:
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       parameters:
         - name: tags
           in: query
@@ -168,11 +168,11 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -202,8 +202,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -233,8 +233,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -260,11 +260,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -298,8 +298,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -350,7 +350,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       operationId: getOrderById
       summary: Find purchase order by ID
@@ -510,7 +510,7 @@ paths:
           description: successful operation
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -789,10 +789,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -802,7 +802,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-default-bug-numbers-x-tag/output.yaml
+++ b/test/yaml-default-bug-numbers-x-tag/output.yaml
@@ -2,12 +2,12 @@ openapi: 3.0.2
 info:
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:

--- a/test/yaml-default-newline/input.yaml
+++ b/test/yaml-default-newline/input.yaml
@@ -1,4 +1,11 @@
 openapi: 3.0.0
 info:
-  description: |2
-     Example
+  title: |2+
+    Maitains new line
+    Maitains new line
+
+  description: |2-
+    Strips new line
+
+  version: |2
+    Example

--- a/test/yaml-default-newline/output.yaml
+++ b/test/yaml-default-newline/output.yaml
@@ -1,4 +1,9 @@
 openapi: 3.0.0
 info:
-  description: |2
-     Example
+  title: |+
+    Maitains new line
+    Maitains new line
+
+  description: Strips new line
+  version: |
+    Example

--- a/test/yaml-default/output.yaml
+++ b/test/yaml-default/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     put:
@@ -91,8 +91,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -131,15 +131,15 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
     get:
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       parameters:
         - name: tags
           in: query
@@ -168,11 +168,11 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -202,8 +202,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -233,8 +233,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -260,11 +260,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -298,8 +298,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -350,7 +350,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       operationId: getOrderById
       summary: Find purchase order by ID
@@ -510,7 +510,7 @@ paths:
           description: successful operation
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -787,10 +787,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -800,7 +800,7 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-filter-custom-default-3.1/output.yaml
+++ b/test/yaml-filter-custom-default-3.1/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -65,15 +65,15 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
     get:
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       parameters:
         - name: tags
           in: query
@@ -102,11 +102,11 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -136,8 +136,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -167,8 +167,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -194,11 +194,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -232,8 +232,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -284,7 +284,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       operationId: getOrderById
       summary: Find purchase order by ID
@@ -445,7 +445,7 @@ paths:
           description: successful operation
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -752,10 +752,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -765,4 +765,4 @@ tags:
     description: Everything about your Pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-filter-custom-flags-flagsValues/output.yaml
+++ b/test/yaml-filter-custom-flags-flagsValues/output.yaml
@@ -13,12 +13,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
@@ -57,8 +57,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -77,7 +77,7 @@ paths:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -107,9 +107,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -141,8 +141,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -172,8 +172,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -199,9 +199,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -231,8 +231,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -287,7 +287,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -447,7 +447,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -524,7 +524,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -727,10 +727,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-flags/output.yaml
+++ b/test/yaml-filter-custom-flags/output.yaml
@@ -13,12 +13,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
@@ -56,8 +56,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -81,7 +81,7 @@ paths:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -111,9 +111,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -145,8 +145,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -176,8 +176,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -203,9 +203,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -235,8 +235,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -291,7 +291,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -451,7 +451,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -528,7 +528,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -731,10 +731,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-flagsvalue-array/output.yaml
+++ b/test/yaml-filter-custom-flagsvalue-array/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     put:
@@ -51,8 +51,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -71,7 +71,7 @@ paths:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       x-version: 3
       parameters:
@@ -102,9 +102,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -136,8 +136,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -167,8 +167,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -194,9 +194,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -226,8 +226,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -282,7 +282,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -442,7 +442,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -519,7 +519,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -722,10 +722,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-flagsvalue-value-array/output.yaml
+++ b/test/yaml-filter-custom-flagsvalue-value-array/output.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.1
 servers:
-  - url: 'https://server-d'
+  - url: https://server-d
     x-stage-e-exclude:
       - false

--- a/test/yaml-filter-custom-flagsvalue-value/output.yaml
+++ b/test/yaml-filter-custom-flagsvalue-value/output.yaml
@@ -13,12 +13,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
@@ -68,9 +68,9 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -102,8 +102,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -133,8 +133,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -160,9 +160,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -192,8 +192,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -248,7 +248,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -408,7 +408,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -485,7 +485,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -688,10 +688,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-methods/output.yaml
+++ b/test/yaml-filter-custom-methods/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -48,8 +48,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -87,8 +87,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -102,7 +102,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Pet'
-  '/pet/{petId}':
+  /pet/{petId}:
     post:
       tags:
         - pet
@@ -132,8 +132,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -159,9 +159,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -191,8 +191,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -227,7 +227,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     delete:
       tags:
         - store
@@ -304,7 +304,7 @@ paths:
               type: array
               items:
                 $ref: '#/components/schemas/User'
-  '/user/{username}':
+  /user/{username}:
     put:
       tags:
         - user
@@ -354,7 +354,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -557,10 +557,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-operationids/output.yaml
+++ b/test/yaml-filter-custom-operationids/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     put:
@@ -51,8 +51,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -71,7 +71,7 @@ paths:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -101,9 +101,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -135,8 +135,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -166,8 +166,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -193,9 +193,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -225,8 +225,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -281,7 +281,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -441,7 +441,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -518,7 +518,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -721,10 +721,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-operations-method-wildcard/output.yaml
+++ b/test/yaml-filter-custom-operations-method-wildcard/output.yaml
@@ -13,25 +13,25 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -61,9 +61,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -95,8 +95,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -126,8 +126,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -153,9 +153,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -185,8 +185,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -241,7 +241,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -401,7 +401,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -478,7 +478,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -681,10 +681,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-operations-path-wildcard/output.yaml
+++ b/test/yaml-filter-custom-operations-path-wildcard/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -48,8 +48,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -87,8 +87,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -102,7 +102,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Pet'
-  '/pet/{petId}':
+  /pet/{petId}:
     post:
       tags:
         - pet
@@ -132,8 +132,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -159,9 +159,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -191,8 +191,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -247,7 +247,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -407,7 +407,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -484,7 +484,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -687,10 +687,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-operations/output.yaml
+++ b/test/yaml-filter-custom-operations/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     put:
@@ -51,8 +51,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -71,7 +71,7 @@ paths:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -101,9 +101,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -135,8 +135,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -166,8 +166,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -193,9 +193,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -225,8 +225,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -281,7 +281,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -441,7 +441,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -518,7 +518,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -721,10 +721,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom-tags/output.yaml
+++ b/test/yaml-filter-custom-tags/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 x-tagGroups:
   - name: Tag Group 1
     tags:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -91,8 +91,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -145,14 +145,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -182,9 +182,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -216,8 +216,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -247,8 +247,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -274,9 +274,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -306,8 +306,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -342,7 +342,7 @@ paths:
               $ref: '#/components/schemas/Order'
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -545,10 +545,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-custom/output.yaml
+++ b/test/yaml-filter-custom/output.yaml
@@ -13,12 +13,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
@@ -48,8 +48,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -68,7 +68,7 @@ paths:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -98,9 +98,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -132,8 +132,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -163,8 +163,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -190,9 +190,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -222,8 +222,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -278,7 +278,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -438,7 +438,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -515,7 +515,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -718,10 +718,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-default/output.yaml
+++ b/test/yaml-filter-default/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
       x-visibility: true
@@ -92,8 +92,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -132,15 +132,15 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
     get:
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       parameters:
         - name: tags
           in: query
@@ -169,11 +169,11 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -203,8 +203,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -234,8 +234,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -261,11 +261,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -299,8 +299,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -351,7 +351,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       operationId: getOrderById
       summary: Find purchase order by ID
@@ -511,7 +511,7 @@ paths:
           description: successful operation
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -786,10 +786,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -799,4 +799,4 @@ tags:
     description: Everything about your Pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-filter-inverse-all-methods/output.yaml
+++ b/test/yaml-filter-inverse-all-methods/output.yaml
@@ -3,7 +3,7 @@ info:
   title: Minimal API
   version: 1.0.0
 servers:
-  - url: 'https://api.example.com/v1'
+  - url: https://api.example.com/v1
 paths:
   /resource:
     head:

--- a/test/yaml-filter-inverse-flags-flagsValues/output.yaml
+++ b/test/yaml-filter-inverse-flags-flagsValues/output.yaml
@@ -5,12 +5,12 @@ info:
   description: This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: store
     description: Everything about your store
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -72,7 +72,7 @@ paths:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       x-release: dev
       parameters:
@@ -103,11 +103,11 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Category:
@@ -180,10 +180,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-inverse-flags/output.yaml
+++ b/test/yaml-filter-inverse-flags/output.yaml
@@ -5,12 +5,12 @@ info:
   description: This is a sample Pet Store Server based on the OpenAPI 3.0 specification.
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: user
     x-visibility: true
@@ -43,8 +43,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -97,11 +97,11 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Category:
@@ -174,10 +174,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-inverse-flagsvalue-value-array/output.yaml
+++ b/test/yaml-filter-inverse-flagsvalue-value-array/output.yaml
@@ -1,5 +1,5 @@
 openapi: 3.0.1
 servers:
-  - url: 'https://server-e'
+  - url: https://server-e
     x-stage:
       - e

--- a/test/yaml-filter-inverse-methods/output.yaml
+++ b/test/yaml-filter-inverse-methods/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet/findByStatus:
     get:
@@ -65,14 +65,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -102,9 +102,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -136,8 +136,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /store/inventory:
     get:
       tags:
@@ -158,7 +158,7 @@ paths:
                   format: int32
       security:
         - api_key: []
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -242,7 +242,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -272,7 +272,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -475,10 +475,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-inverse-operationids-free-form/output.yaml
+++ b/test/yaml-filter-inverse-operationids-free-form/output.yaml
@@ -1,9 +1,9 @@
 openapi: 3.0.2
 info:
   title: OpenSearch
-  version: '2021-11-23'
+  version: 2021-11-23
 paths:
-  '/_cat/indices/{index}':
+  /_cat/indices/{index}:
     get:
       description: 'Returns information about indices: number of primaries and replicas, document counts, disk size, etc.'
       operationId: GetCatIndicesWithIndex
@@ -12,7 +12,7 @@ paths:
           in: path
           schema:
             type: string
-            pattern: '^[^+_\-\.][^\\, /*?"<>| ,#\nA-Z]+$'
+            pattern: ^[^+_\-\.][^\\, /*?"<>| ,#\nA-Z]+$
           required: true
           example: books
         - name: bytes
@@ -42,12 +42,12 @@ paths:
           in: query
           schema:
             type: string
-            pattern: '^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$'
+            pattern: ^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$
         - name: timeout
           in: query
           schema:
             type: string
-            pattern: '^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$'
+            pattern: ^([0-9]+)(?:d|h|m|s|ms|micros|nanos)$
       responses:
         '200':
           description: GetCatIndicesWithIndex 200 response

--- a/test/yaml-filter-inverse-operationids/output.yaml
+++ b/test/yaml-filter-inverse-operationids/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -48,8 +48,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -102,11 +102,11 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -309,10 +309,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-inverse-request-content/output.yaml
+++ b/test/yaml-filter-inverse-request-content/output.yaml
@@ -32,8 +32,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
 components:
   schemas:
     Category:
@@ -87,10 +87,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-inverse-response-content/output.yaml
+++ b/test/yaml-filter-inverse-response-content/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -45,8 +45,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -81,8 +81,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -130,14 +130,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -162,9 +162,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -193,8 +193,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -224,8 +224,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -251,9 +251,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -283,8 +283,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -339,7 +339,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -487,7 +487,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -561,7 +561,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -764,10 +764,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-inverse-tags/output.yaml
+++ b/test/yaml-filter-inverse-tags/output.yaml
@@ -13,23 +13,23 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: user
     description: Everything about your users
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
   - name: store
     description: Everything about your store
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 x-tagGroups:
   - name: Tag Group 2
     tags:
@@ -56,7 +56,7 @@ paths:
                   format: int32
       security:
         - api_key: []
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -216,7 +216,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -293,7 +293,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -494,10 +494,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-markdown-comments/output.yaml
+++ b/test/yaml-filter-markdown-comments/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
@@ -45,8 +45,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -84,8 +84,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -138,14 +138,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -175,9 +175,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -209,8 +209,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -240,8 +240,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -267,9 +267,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -299,8 +299,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -443,7 +443,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -526,7 +526,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     ErrorModel:
@@ -741,10 +741,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-replace-text/output.yaml
+++ b/test/yaml-filter-replace-text/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Animal Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'https://www.apache.org/licenses/LICENSE-2.0.html'
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Animals
@@ -47,8 +47,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -86,8 +86,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -140,14 +140,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Animals by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -177,9 +177,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -211,8 +211,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -242,8 +242,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -269,9 +269,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -301,8 +301,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -355,7 +355,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -515,7 +515,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -592,7 +592,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://openapis.org/'
+  url: http://openapis.org/
 components:
   schemas:
     ErrorModel:
@@ -807,10 +807,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-request-content/output.yaml
+++ b/test/yaml-filter-request-content/output.yaml
@@ -35,8 +35,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
 components:
   schemas:
     Category:
@@ -90,10 +90,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-response-content/output.yaml
+++ b/test/yaml-filter-response-content/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -45,8 +45,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -81,8 +81,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -130,14 +130,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -162,9 +162,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -193,8 +193,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -224,8 +224,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -251,9 +251,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -279,8 +279,8 @@ paths:
           description: successful operation
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -324,7 +324,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -472,7 +472,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -546,7 +546,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -749,10 +749,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-filter-security-empty/output.yaml
+++ b/test/yaml-filter-security-empty/output.yaml
@@ -3,12 +3,12 @@ info:
   description: Sample
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -119,10 +119,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -132,7 +132,7 @@ tags:
     description: Everything about your Pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 security:
   - BasicAuth: []
   - {}

--- a/test/yaml-filter-unused-components/output.yaml
+++ b/test/yaml-filter-unused-components/output.yaml
@@ -13,12 +13,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
@@ -49,8 +49,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -88,8 +88,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -142,14 +142,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -179,9 +179,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -213,8 +213,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -244,8 +244,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -271,9 +271,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -303,8 +303,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -357,7 +357,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -517,7 +517,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -589,7 +589,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -744,10 +744,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-linewidth/output.yaml
+++ b/test/yaml-linewidth/output.yaml
@@ -2,42 +2,29 @@ openapi: 3.0.2
 servers:
   - url: /v3
 info:
-  description: >-
-    This is a sample Pet Store Server based on the OpenAPI
-    3.0 specification.  You can find out more about
-
-    Swagger at [http://swagger.io](http://swagger.io). In
-    the third iteration of the pet store, we've switched to
-    the design first approach!
-
-    You can now help us improve the API whether it's by
-    making changes to the definition itself or to the code.
-
-    That way, with time, we can improve the API in general,
-    and expose some of the new features in OAS3.
-
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+    You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+    That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
 
     Some useful links:
-
-    - [The Pet Store
-    repository](https://github.com/swagger-api/swagger-petstore)
-
-    - [The source API definition for the Pet
-    Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -61,8 +48,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -100,8 +87,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -120,15 +107,13 @@ paths:
       tags:
         - pet
       summary: Finds Pets by status
-      description: >-
-        Multiple status values can be provided with comma
-        separated strings
+      description: Multiple status values can be provided with
+        comma separated strings
       operationId: findPetsByStatus
       parameters:
         - name: status
           in: query
-          description: >-
-            Status values that need to be considered for
+          description: Status values that need to be considered for
             filter
           required: false
           explode: true
@@ -157,16 +142,15 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: >-
-        Multiple tags can be provided with comma separated
-        strings. Use tag1, tag2, tag3 for testing.
+      description: Multiple tags can be provided with comma
+        separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -196,9 +180,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -230,8 +214,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -261,8 +245,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -288,9 +272,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -320,8 +304,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -376,15 +360,14 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
       summary: Find purchase order by ID
       x-swagger-router-controller: OrderController
-      description: >-
-        For valid response try integer IDs with value <= 5
-        or > 10. Other values will generated exceptions
+      description: For valid response try integer IDs with value
+        <= 5 or > 10. Other values will generated exceptions
       operationId: getOrderById
       parameters:
         - name: orderId
@@ -413,8 +396,7 @@ paths:
         - store
       summary: Delete purchase order by ID
       x-swagger-router-controller: OrderController
-      description: >-
-        For valid response try integer IDs with value <
+      description: For valid response try integer IDs with value <
         1000. Anything above 1000 or nonintegers will
         generate API errors
       operationId: deleteOrder
@@ -541,7 +523,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -551,9 +533,8 @@ paths:
       parameters:
         - name: username
           in: path
-          description: >-
-            The name that needs to be fetched. Use user1 for
-            testing. 
+          description: 'The name that needs to be fetched. Use user1
+            for testing. '
           required: true
           schema:
             type: string
@@ -620,7 +601,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -823,10 +804,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-no-sort-keep-comments/output.yaml
+++ b/test/yaml-no-sort-keep-comments/output.yaml
@@ -4,7 +4,8 @@ info:
   version: 1.0.0
 paths:
   /example:
-    get: # This is a comment in the OpenAPI file
+    get:
+      # This is a comment in the OpenAPI file
       description: The description of the example # This is a comment in the OpenAPI file
       # This is a comment in the OpenAPI file
       summary: Returns an example

--- a/test/yaml-no-sort/output.yaml
+++ b/test/yaml-no-sort/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -48,8 +48,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -87,8 +87,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -140,14 +140,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -177,9 +177,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -211,8 +211,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -242,8 +242,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -269,9 +269,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -301,8 +301,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -357,7 +357,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -517,7 +517,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -594,7 +594,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -797,10 +797,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-preserve-empty-no-filter/output.yaml
+++ b/test/yaml-preserve-empty-no-filter/output.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   description: Test
 servers:
-  - url: 'https://example.de/test'
+  - url: https://example.de/test
 security:
   - bearerToken: []
 tags:

--- a/test/yaml-preserve-empty-objects-default/output.yaml
+++ b/test/yaml-preserve-empty-objects-default/output.yaml
@@ -3,12 +3,12 @@ info:
   description: Sample
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -136,10 +136,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -149,7 +149,7 @@ tags:
     description: Everything about your Pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 security:
   - BasicAuth: []
   - {}

--- a/test/yaml-preserve-empty-objects-false/output.yaml
+++ b/test/yaml-preserve-empty-objects-false/output.yaml
@@ -3,12 +3,12 @@ info:
   description: Sample
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -119,10 +119,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -132,7 +132,7 @@ tags:
     description: Everything about your Pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 security:
   - BasicAuth: []
   - {}

--- a/test/yaml-preserve-empty-objects-schema-only/output.yaml
+++ b/test/yaml-preserve-empty-objects-schema-only/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -48,8 +48,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -86,8 +86,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -140,14 +140,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -177,9 +177,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -211,8 +211,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -242,8 +242,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -267,9 +267,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -299,8 +299,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /store/inventory:
     get:
       tags:
@@ -349,7 +349,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -509,7 +509,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -586,7 +586,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -789,10 +789,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-preserve-empty-objects-true/output.yaml
+++ b/test/yaml-preserve-empty-objects-true/output.yaml
@@ -3,12 +3,12 @@ info:
   description: Sample
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -136,10 +136,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key
@@ -149,7 +149,7 @@ tags:
     description: Everything about your Pets
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 security:
   - BasicAuth: []
   - {}

--- a/test/yaml-ref-quotes/output.yaml
+++ b/test/yaml-ref-quotes/output.yaml
@@ -6,6 +6,6 @@ components:
       type: object
       properties:
         extern:
-          $ref: "domain-types.openapi.yaml#/components/schemas/Extern"
+          $ref: domain-types.openapi.yaml#/components/schemas/Extern
         intern:
-          $ref: "domain-types.openapi.yaml#/components/schemas/Extern"
+          $ref: domain-types.openapi.yaml#/components/schemas/Extern

--- a/test/yaml-remove-empty-filter/output.yaml
+++ b/test/yaml-remove-empty-filter/output.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   description: Test
 servers:
-  - url: 'https://example.de/test'
+  - url: https://example.de/test
 security:
   - bearerToken: []
 tags:

--- a/test/yaml-rename/output.yaml
+++ b/test/yaml-rename/output.yaml
@@ -13,18 +13,18 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: OpenAPI Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     post:
@@ -48,8 +48,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Create a new pet in the store
         required: true
@@ -87,8 +87,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         description: Update an existent pet in the store
         required: true
@@ -140,14 +140,14 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: findPetsByTags
       parameters:
         - name: tags
@@ -177,9 +177,9 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}':
+            - write:pets
+            - read:pets
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -211,8 +211,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     post:
       tags:
         - pet
@@ -242,8 +242,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
     delete:
       tags:
         - pet
@@ -269,9 +269,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -301,8 +301,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -357,7 +357,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -517,7 +517,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -594,7 +594,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -797,10 +797,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-sort-components/output.yaml
+++ b/test/yaml-sort-components/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
       x-visibility: true
@@ -92,8 +92,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -132,15 +132,15 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
     get:
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       parameters:
         - name: tags
           in: query
@@ -169,11 +169,11 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -203,8 +203,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -234,8 +234,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -261,11 +261,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -299,8 +299,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -351,7 +351,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       operationId: getOrderById
       summary: Find purchase order by ID
@@ -511,7 +511,7 @@ paths:
           description: successful operation
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -792,16 +792,16 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-sort-keep-comments/output.yaml
+++ b/test/yaml-sort-keep-comments/output.yaml
@@ -4,7 +4,8 @@ info:
   version: 1.0.0
 paths:
   /example:
-    get: # 1 - This is a comment in the OpenAPI file
+    get:
+      # 1 - This is a comment in the OpenAPI file
       # 3 - This is a comment in the OpenAPI file
       summary: Returns an example # 4 - This is a comment in the OpenAPI file
       description: The description of the example # 2 - This is a comment in the OpenAPI file

--- a/test/yaml-sort-skip-components/output.yaml
+++ b/test/yaml-sort-skip-components/output.yaml
@@ -11,12 +11,12 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 servers:
   - url: /v3
 paths:
@@ -52,8 +52,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
       x-visibility: true
@@ -92,8 +92,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByStatus:
@@ -132,15 +132,15 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /pet/findByTags:
     get:
       operationId: findPetsByTags
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       parameters:
         - name: tags
           in: query
@@ -169,11 +169,11 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       operationId: getPetById
       summary: Find pet by ID
@@ -203,8 +203,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     post:
@@ -234,8 +234,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
     delete:
@@ -261,11 +261,11 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       operationId: uploadFile
       summary: uploads an image
@@ -299,8 +299,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       tags:
         - pet
   /store/inventory:
@@ -351,7 +351,7 @@ paths:
       tags:
         - store
       x-swagger-router-controller: OrderController
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       operationId: getOrderById
       summary: Find purchase order by ID
@@ -511,7 +511,7 @@ paths:
           description: successful operation
       tags:
         - user
-  '/user/{username}':
+  /user/{username}:
     get:
       operationId: getUserByName
       summary: Get user by user name
@@ -792,16 +792,16 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io

--- a/test/yaml-stoplight-studio-style/output.yaml
+++ b/test/yaml-stoplight-studio-style/output.yaml
@@ -10,16 +10,16 @@ info:
     Some useful links:
     - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: 1.0.5-SNAPSHOT
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 servers:
   - url: /v3
 tags:
@@ -27,14 +27,14 @@ tags:
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
   - name: store
     description: Operations about user
   - name: user
     description: Access to Petstore orders
     externalDocs:
       description: Find out more about our store
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
   /pet:
     put:
@@ -74,8 +74,8 @@ paths:
           description: Validation exception
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       x-openapi-router-controller: swagger_server.controllers.pet_controller
     post:
       tags:
@@ -110,8 +110,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       x-openapi-router-controller: swagger_server.controllers.pet_controller
   /pet/findByStatus:
     get:
@@ -153,15 +153,15 @@ paths:
           description: Invalid status value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       x-openapi-router-controller: swagger_server.controllers.pet_controller
   /pet/findByTags:
     get:
       tags:
         - pet
       summary: Finds Pets by tags
-      description: 'Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.'
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
       operationId: find_pets_by_tags
       parameters:
         - name: tags
@@ -193,10 +193,10 @@ paths:
           description: Invalid tag value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       x-openapi-router-controller: swagger_server.controllers.pet_controller
-  '/pet/{petId}':
+  /pet/{petId}:
     get:
       tags:
         - pet
@@ -230,8 +230,8 @@ paths:
       security:
         - api_key: []
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       x-openapi-router-controller: swagger_server.controllers.pet_controller
     post:
       tags:
@@ -269,8 +269,8 @@ paths:
           description: Invalid input
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       x-openapi-router-controller: swagger_server.controllers.pet_controller
     delete:
       tags:
@@ -299,10 +299,10 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       x-openapi-router-controller: swagger_server.controllers.pet_controller
-  '/pet/{petId}/uploadImage':
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -341,8 +341,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       x-openapi-router-controller: swagger_server.controllers.pet_controller
   /store/inventory:
     get:
@@ -395,7 +395,7 @@ paths:
           description: Invalid input
       x-swagger-router-controller: OrderController
       x-openapi-router-controller: swagger_server.controllers.store_controller
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -572,7 +572,7 @@ paths:
         default:
           description: successful operation
       x-openapi-router-controller: swagger_server.controllers.user_controller
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -689,7 +689,7 @@ components:
         petId: 198772
         quantity: 7
         id: 10
-        shipDate: '2000-01-23T04:56:07.000+00:00'
+        shipDate: 2000-01-23T04:56:07.000+00:00
         complete: true
         status: approved
       xml:
@@ -896,10 +896,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
       x-tokenInfoFunc: swagger_server.controllers.authorization_controller.check_petstore_auth
       x-scopeValidateFunc: swagger_server.controllers.authorization_controller.validate_scope_petstore_auth
     api_key:

--- a/test/yaml-strip-flags/output.yaml
+++ b/test/yaml-strip-flags/output.yaml
@@ -13,20 +13,20 @@ info:
     - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
   version: 1.0.6-SNAPSHOT
   title: Swagger Petstore - OpenAPI 3.0
-  termsOfService: 'http://swagger.io/terms/'
+  termsOfService: http://swagger.io/terms/
   contact:
     email: apiteam@swagger.io
   license:
     name: Apache 2.0
-    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
 tags:
   - name: pet
     description: Everything about your Pets
     externalDocs:
       description: Find out more
-      url: 'http://swagger.io'
+      url: http://swagger.io
 paths:
-  '/pet/{petId}':
+  /pet/{petId}:
     delete:
       tags:
         - pet
@@ -52,9 +52,9 @@ paths:
           description: Invalid pet value
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
-  '/pet/{petId}/uploadImage':
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
     post:
       tags:
         - pet
@@ -84,8 +84,8 @@ paths:
                 $ref: '#/components/schemas/ApiResponse'
       security:
         - petstore_auth:
-            - 'write:pets'
-            - 'read:pets'
+            - write:pets
+            - read:pets
       requestBody:
         content:
           application/octet-stream:
@@ -138,7 +138,7 @@ paths:
           application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/Order'
-  '/store/order/{orderId}':
+  /store/order/{orderId}:
     get:
       tags:
         - store
@@ -295,7 +295,7 @@ paths:
       responses:
         default:
           description: successful operation
-  '/user/{username}':
+  /user/{username}:
     get:
       tags:
         - user
@@ -371,7 +371,7 @@ paths:
           description: User not found
 externalDocs:
   description: Find out more about Swagger
-  url: 'http://swagger.io'
+  url: http://swagger.io
 components:
   schemas:
     Order:
@@ -574,10 +574,10 @@ components:
       type: oauth2
       flows:
         implicit:
-          authorizationUrl: 'https://petstore.swagger.io/oauth/authorize'
+          authorizationUrl: https://petstore.swagger.io/oauth/authorize
           scopes:
-            'write:pets': modify pets in your account
-            'read:pets': read your pets
+            write:pets: modify pets in your account
+            read:pets: read your pets
     api_key:
       type: apiKey
       name: api_key

--- a/test/yaml-unused-extra/output.yaml
+++ b/test/yaml-unused-extra/output.yaml
@@ -2,11 +2,11 @@ openapi: 3.0.3
 info:
   title: Marvel Universe API
   version: 1.0.0
-  description: 'API for retrieving, creating, updating, and deleting information about the Marvel Universe.'
+  description: API for retrieving, creating, updating, and deleting information about the Marvel Universe.
   x-logo:
-    url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Marvel-Comics-Logo.svg/1280px-Marvel-Comics-Logo.svg.png'
+    url: https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Marvel-Comics-Logo.svg/1280px-Marvel-Comics-Logo.svg.png
 servers:
-  - url: 'http://localhost:3004/api'
+  - url: http://localhost:3004/api
     description: Production
 paths:
   /characters:
@@ -86,7 +86,7 @@ components:
         description:
           description: A brief description of the Marvel character.
           type: string
-          example: 'Genius, billionaire, playboy, philanthropist.'
+          example: Genius, billionaire, playboy, philanthropist.
           nullable: true
         powers:
           description: List of superpowers possessed by the Marvel character.
@@ -113,7 +113,7 @@ components:
               name: Iron Man
               first_name: Tony
               last_name: Stark
-              description: 'Genius, billionaire, playboy, philanthropist.'
+              description: Genius, billionaire, playboy, philanthropist.
               powers:
                 - Superhuman strength
                 - Powered armor suit

--- a/utils/file.js
+++ b/utils/file.js
@@ -1,9 +1,116 @@
 const fs = require('fs');
 const bundler = require('api-ref-bundler');
-const yaml = require('@stoplight/yaml');
+const yaml = require('yaml');
 const http = require('http');
 const https = require('https');
 const {dirname} = require('path');
+
+const COMMENT_TYPE = /** @type {const} */ ({
+  INLINE_VALUE: 'inlineValue',
+  INLINE_KEY: 'inlineKey',
+  BEFORE_KEY: 'beforeKey',
+  BEFORE_VALUE: 'beforeBlock'
+});
+
+/**
+ * @typedef {typeof COMMENT_TYPE[keyof typeof COMMENT_TYPE]} CommentType
+ */
+
+/**
+ * @typedef {Object} Comment
+ * @property {string[]} path
+ * @property {CommentType} type
+ * @property {string} text
+ */
+
+/**
+ * Walk a parsed YAML Document and extract comments keyed by their property path.
+ * @param {import('yaml').Document} doc
+ * @returns {Array<{path: string[], type: string, text: string}>}
+ */
+function extractComments(doc) {
+  /** @type {Comment[]} */
+  const comments = [];
+
+  yaml.visit(doc, {
+    // Comments in YAML are always attached to Pair nodes (key: value entries),
+    // so visiting only Pair is sufficient to capture all of them.
+    Pair(_, pair, path) {
+      if (!pair.key || pair.key.value == null) return;
+
+      const keyPath = [];
+      for (const ancestor of path) {
+        if (yaml.isPair(ancestor) && ancestor.key?.value != null) {
+          keyPath.push(String(ancestor.key.value));
+        }
+      }
+      keyPath.push(String(pair.key.value));
+
+      // inline key comment  (only on null explicit key mapping)
+      // ? key # comment
+      if (pair.key.comment != null) {
+        comments.push({path: keyPath, type: COMMENT_TYPE.INLINE_KEY, text: pair.key.comment});
+      }
+
+      // inline value comment
+      // key: value # comment
+      if (pair.value?.comment != null) {
+        comments.push({path: keyPath, type: COMMENT_TYPE.INLINE_VALUE, text: pair.value.comment});
+      }
+
+      // comment before a key
+      // # comment
+      // key: value
+      if (pair.key.commentBefore != null) {
+        comments.push({path: keyPath, type: COMMENT_TYPE.BEFORE_KEY, text: pair.key.commentBefore});
+      }
+
+      // comment before a value
+      // key: # comment
+      //   value
+      if (pair.value?.commentBefore != null) {
+        comments.push({path: keyPath, type: COMMENT_TYPE.BEFORE_VALUE, text: pair.value.commentBefore});
+      }
+    }
+  });
+
+  return comments;
+}
+
+/**
+ * Re-inject comments extracted by extractComments into a new YAML Document,
+ * matching nodes by key path.
+ * @param {import('yaml').Document} doc
+ * @param {Comment[]} comments
+ */
+function injectComments(doc, comments) {
+  for (const {path, type, text} of comments) {
+    const parentPath = path.slice(0, -1);
+    const key = path[path.length - 1];
+
+    const parentNode = parentPath.length === 0 ? doc.contents : doc.getIn(parentPath, true);
+
+    if (parentNode && yaml.isMap(parentNode)) {
+      const pair = parentNode.items.find(p => p.key && String(p.key.value) === key);
+      if (pair) {
+        switch (type) {
+          case COMMENT_TYPE.BEFORE_KEY:
+            pair.key.commentBefore = text;
+            break;
+          case COMMENT_TYPE.BEFORE_VALUE:
+            pair.value.commentBefore = text;
+            break;
+          case COMMENT_TYPE.INLINE_KEY:
+            pair.key.comment = text;
+            break;
+          case COMMENT_TYPE.INLINE_VALUE:
+            pair.value.comment = text;
+            break;
+        }
+      }
+    }
+  }
+}
 
 /**
  * Converts a string object to a JSON/YAML object.
@@ -26,9 +133,11 @@ async function parseString(str, options = {}) {
 
   if (toYaml) {
     try {
-      const result = yaml.parseWithPointers(encodedContent, {attachComments: options?.keepComments || false});
-      options.yamlComments = result.comments;
-      const obj = normalizeYamlBlockScalarNewlines(result.data);
+      const doc = yaml.parseDocument(encodedContent);
+      if (options?.keepComments) {
+        options.yamlComments = extractComments(doc);
+      }
+      const obj = doc.toJS();
       if (typeof obj === 'object') {
         return obj;
       } else {
@@ -163,18 +272,16 @@ async function stringify(obj, options = {}) {
     const toYaml = options.format !== 'json' && (!options.hasOwnProperty('json') || options.json !== true);
 
     if (toYaml) {
-      // Set YAML options
-      const yamlOptions = {};
-      yamlOptions.lineWidth =
-        (options.lineWidth && options.lineWidth === -1 ? Infinity : options.lineWidth) || Infinity;
-
-      if (options?.yamlComments && options?.keepComments === true) {
-        yamlOptions.comments = options.yamlComments;
-      }
+      const lineWidth = (options.lineWidth && options.lineWidth === -1 ? 0 : options.lineWidth) || 0;
 
       // Convert object to YAML string
-      output = yaml.safeStringify(obj, yamlOptions);
-      output = addQuotesToRefInString(output);
+      output = yaml.stringify(obj, {lineWidth, singleQuote: true});
+
+      if (options?.yamlComments?.length > 0 && options?.keepComments === true) {
+        const newDoc = yaml.parseDocument(output);
+        injectComments(newDoc, options.yamlComments);
+        output = newDoc.toString();
+      }
 
       // Decode large number YAML values safely before writing output
       output = decodeLargeNumbers(output);
@@ -335,36 +442,7 @@ function decodeLargeNumbers(output, isJson = false) {
  * @returns {string} YAML string with quotes.
  */
 function addQuotesToRefInString(yamlString) {
-  return yamlString.replace(/(\$ref:\s*)([^"'\s>]+)/g, '$1"$2"');
-}
-
-/**
- * Normalize a parser artifact where block scalars with indentation indicators
- * gain a spurious leading newline during YAML parsing.
- * This keeps genuine blank first lines intact by only stripping a single
- * leading newline when the string also has a trailing newline.
- * @param {*} value - Parsed YAML value.
- * @returns {*} Normalized value.
- */
-function normalizeYamlBlockScalarNewlines(value) {
-  if (typeof value === 'string') {
-    if (value.startsWith('\n') && !value.startsWith('\n\n') && value.endsWith('\n')) {
-      return value.slice(1);
-    }
-    return value;
-  }
-
-  if (Array.isArray(value)) {
-    return value.map(item => normalizeYamlBlockScalarNewlines(item));
-  }
-
-  if (value && typeof value === 'object') {
-    for (const key of Object.keys(value)) {
-      value[key] = normalizeYamlBlockScalarNewlines(value[key]);
-    }
-  }
-
-  return value;
+  return yamlString.replace(/(\$ref:\s*)([^"'\s>]+)/g, "$1'$2'");
 }
 
 /**


### PR DESCRIPTION
  > [!IMPORTANT]
  > Splitted into commits for easier review — happy to squash before merge, or keep it as is.

 Fixes #149, #202

  I'd like to propose replacing stoplight/yaml with https://github.com/eemeli/yaml. Open to feedback on the approach before this goes further.

  ## Problem

  stoplight/yaml has multiple unfixed bugs and limitations:
 
  - Block scalar chomping (|+) loses trailing blank lines
  - Explicit indent indicators (|2) produce a spurious leading newline
  - Both stoplight/yaml and its underlying parser stoplight/yaml-ast-parser (a fork of js-yaml) are effectively unmaintained
   - Unnecessarily quotes valid YAML strings and forces all double-quoted strings to single quotes (https://github.com/stoplightio/yaml/issues/78)

 ## Solution

  Replace stoplight/yaml with the actively maintained https://github.com/eemeli/yaml package. Comment preservation is re-implemented using a path-based extract/inject strategy. This also unlocks greater flexibility going forward, due to the  yaml package exposing a  AST which give us fine-grained control. Also it provides multiple configuration options.
